### PR TITLE
Full rework of Ethernet HAL driver

### DIFF
--- a/Inc/stm32f7xx_hal_eth.h
+++ b/Inc/stm32f7xx_hal_eth.h
@@ -17,17 +17,18 @@
   */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
-#ifndef __STM32F7xx_HAL_ETH_H
-#define __STM32F7xx_HAL_ETH_H
+#ifndef STM32F7xx_HAL_ETH_H
+#define STM32F7xx_HAL_ETH_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
+
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f7xx_hal_def.h"
 
-#if defined (ETH)
+#if defined(ETH)
 
 /** @addtogroup STM32F7xx_HAL_Driver
   * @{
@@ -35,616 +36,559 @@
 
 /** @addtogroup ETH
   * @{
-  */ 
-  
-/** @addtogroup ETH_Private_Macros
-  * @{
-  */
-#define IS_ETH_PHY_ADDRESS(ADDRESS) ((ADDRESS) <= 0x20)
-#define IS_ETH_AUTONEGOTIATION(CMD) (((CMD) == ETH_AUTONEGOTIATION_ENABLE) || \
-                                     ((CMD) == ETH_AUTONEGOTIATION_DISABLE))
-#define IS_ETH_SPEED(SPEED) (((SPEED) == ETH_SPEED_10M) || \
-                             ((SPEED) == ETH_SPEED_100M))
-#define IS_ETH_DUPLEX_MODE(MODE)  (((MODE) == ETH_MODE_FULLDUPLEX) || \
-                                  ((MODE) == ETH_MODE_HALFDUPLEX))
-#define IS_ETH_RX_MODE(MODE)    (((MODE) == ETH_RXPOLLING_MODE) || \
-                                 ((MODE) == ETH_RXINTERRUPT_MODE)) 
-#define IS_ETH_CHECKSUM_MODE(MODE)    (((MODE) == ETH_CHECKSUM_BY_HARDWARE) || \
-                                      ((MODE) == ETH_CHECKSUM_BY_SOFTWARE))
-#define IS_ETH_MEDIA_INTERFACE(MODE)         (((MODE) == ETH_MEDIA_INTERFACE_MII) || \
-                                              ((MODE) == ETH_MEDIA_INTERFACE_RMII))
-#define IS_ETH_WATCHDOG(CMD) (((CMD) == ETH_WATCHDOG_ENABLE) || \
-                              ((CMD) == ETH_WATCHDOG_DISABLE))
-#define IS_ETH_JABBER(CMD) (((CMD) == ETH_JABBER_ENABLE) || \
-                            ((CMD) == ETH_JABBER_DISABLE))
-#define IS_ETH_INTER_FRAME_GAP(GAP) (((GAP) == ETH_INTERFRAMEGAP_96BIT) || \
-                                     ((GAP) == ETH_INTERFRAMEGAP_88BIT) || \
-                                     ((GAP) == ETH_INTERFRAMEGAP_80BIT) || \
-                                     ((GAP) == ETH_INTERFRAMEGAP_72BIT) || \
-                                     ((GAP) == ETH_INTERFRAMEGAP_64BIT) || \
-                                     ((GAP) == ETH_INTERFRAMEGAP_56BIT) || \
-                                     ((GAP) == ETH_INTERFRAMEGAP_48BIT) || \
-                                     ((GAP) == ETH_INTERFRAMEGAP_40BIT))
-#define IS_ETH_CARRIER_SENSE(CMD) (((CMD) == ETH_CARRIERSENCE_ENABLE) || \
-                                   ((CMD) == ETH_CARRIERSENCE_DISABLE))
-#define IS_ETH_RECEIVE_OWN(CMD) (((CMD) == ETH_RECEIVEOWN_ENABLE) || \
-                                 ((CMD) == ETH_RECEIVEOWN_DISABLE))
-#define IS_ETH_LOOPBACK_MODE(CMD) (((CMD) == ETH_LOOPBACKMODE_ENABLE) || \
-                                   ((CMD) == ETH_LOOPBACKMODE_DISABLE))
-#define IS_ETH_CHECKSUM_OFFLOAD(CMD) (((CMD) == ETH_CHECKSUMOFFLAOD_ENABLE) || \
-                                      ((CMD) == ETH_CHECKSUMOFFLAOD_DISABLE))
-#define IS_ETH_RETRY_TRANSMISSION(CMD) (((CMD) == ETH_RETRYTRANSMISSION_ENABLE) || \
-                                        ((CMD) == ETH_RETRYTRANSMISSION_DISABLE))
-#define IS_ETH_AUTOMATIC_PADCRC_STRIP(CMD) (((CMD) == ETH_AUTOMATICPADCRCSTRIP_ENABLE) || \
-                                            ((CMD) == ETH_AUTOMATICPADCRCSTRIP_DISABLE))
-#define IS_ETH_BACKOFF_LIMIT(LIMIT) (((LIMIT) == ETH_BACKOFFLIMIT_10) || \
-                                     ((LIMIT) == ETH_BACKOFFLIMIT_8) || \
-                                     ((LIMIT) == ETH_BACKOFFLIMIT_4) || \
-                                     ((LIMIT) == ETH_BACKOFFLIMIT_1))
-#define IS_ETH_DEFERRAL_CHECK(CMD) (((CMD) == ETH_DEFFERRALCHECK_ENABLE) || \
-                                    ((CMD) == ETH_DEFFERRALCHECK_DISABLE))
-#define IS_ETH_RECEIVE_ALL(CMD) (((CMD) == ETH_RECEIVEALL_ENABLE) || \
-                                 ((CMD) == ETH_RECEIVEAll_DISABLE))
-#define IS_ETH_SOURCE_ADDR_FILTER(CMD) (((CMD) == ETH_SOURCEADDRFILTER_NORMAL_ENABLE) || \
-                                        ((CMD) == ETH_SOURCEADDRFILTER_INVERSE_ENABLE) || \
-                                        ((CMD) == ETH_SOURCEADDRFILTER_DISABLE))
-#define IS_ETH_CONTROL_FRAMES(PASS) (((PASS) == ETH_PASSCONTROLFRAMES_BLOCKALL) || \
-                                     ((PASS) == ETH_PASSCONTROLFRAMES_FORWARDALL) || \
-                                     ((PASS) == ETH_PASSCONTROLFRAMES_FORWARDPASSEDADDRFILTER))
-#define IS_ETH_BROADCAST_FRAMES_RECEPTION(CMD) (((CMD) == ETH_BROADCASTFRAMESRECEPTION_ENABLE) || \
-                                                ((CMD) == ETH_BROADCASTFRAMESRECEPTION_DISABLE))
-#define IS_ETH_DESTINATION_ADDR_FILTER(FILTER) (((FILTER) == ETH_DESTINATIONADDRFILTER_NORMAL) || \
-                                                ((FILTER) == ETH_DESTINATIONADDRFILTER_INVERSE))
-#define IS_ETH_PROMISCUOUS_MODE(CMD) (((CMD) == ETH_PROMISCUOUS_MODE_ENABLE) || \
-                                      ((CMD) == ETH_PROMISCUOUS_MODE_DISABLE))
-#define IS_ETH_MULTICAST_FRAMES_FILTER(FILTER) (((FILTER) == ETH_MULTICASTFRAMESFILTER_PERFECTHASHTABLE) || \
-                                                ((FILTER) == ETH_MULTICASTFRAMESFILTER_HASHTABLE) || \
-                                                ((FILTER) == ETH_MULTICASTFRAMESFILTER_PERFECT) || \
-                                                ((FILTER) == ETH_MULTICASTFRAMESFILTER_NONE))
-#define IS_ETH_UNICAST_FRAMES_FILTER(FILTER) (((FILTER) == ETH_UNICASTFRAMESFILTER_PERFECTHASHTABLE) || \
-                                              ((FILTER) == ETH_UNICASTFRAMESFILTER_HASHTABLE) || \
-                                              ((FILTER) == ETH_UNICASTFRAMESFILTER_PERFECT))
-#define IS_ETH_PAUSE_TIME(TIME) ((TIME) <= 0xFFFF)
-#define IS_ETH_ZEROQUANTA_PAUSE(CMD)   (((CMD) == ETH_ZEROQUANTAPAUSE_ENABLE) || \
-                                        ((CMD) == ETH_ZEROQUANTAPAUSE_DISABLE))
-#define IS_ETH_PAUSE_LOW_THRESHOLD(THRESHOLD) (((THRESHOLD) == ETH_PAUSELOWTHRESHOLD_MINUS4) || \
-                                               ((THRESHOLD) == ETH_PAUSELOWTHRESHOLD_MINUS28) || \
-                                               ((THRESHOLD) == ETH_PAUSELOWTHRESHOLD_MINUS144) || \
-                                               ((THRESHOLD) == ETH_PAUSELOWTHRESHOLD_MINUS256))
-#define IS_ETH_UNICAST_PAUSE_FRAME_DETECT(CMD) (((CMD) == ETH_UNICASTPAUSEFRAMEDETECT_ENABLE) || \
-                                                ((CMD) == ETH_UNICASTPAUSEFRAMEDETECT_DISABLE))
-#define IS_ETH_RECEIVE_FLOWCONTROL(CMD) (((CMD) == ETH_RECEIVEFLOWCONTROL_ENABLE) || \
-                                         ((CMD) == ETH_RECEIVEFLOWCONTROL_DISABLE))
-#define IS_ETH_TRANSMIT_FLOWCONTROL(CMD) (((CMD) == ETH_TRANSMITFLOWCONTROL_ENABLE) || \
-                                          ((CMD) == ETH_TRANSMITFLOWCONTROL_DISABLE))
-#define IS_ETH_VLAN_TAG_COMPARISON(COMPARISON) (((COMPARISON) == ETH_VLANTAGCOMPARISON_12BIT) || \
-                                                ((COMPARISON) == ETH_VLANTAGCOMPARISON_16BIT))
-#define IS_ETH_VLAN_TAG_IDENTIFIER(IDENTIFIER) ((IDENTIFIER) <= 0xFFFF)
-#define IS_ETH_MAC_ADDRESS0123(ADDRESS) (((ADDRESS) == ETH_MAC_ADDRESS0) || \
-                                         ((ADDRESS) == ETH_MAC_ADDRESS1) || \
-                                         ((ADDRESS) == ETH_MAC_ADDRESS2) || \
-                                         ((ADDRESS) == ETH_MAC_ADDRESS3))
-#define IS_ETH_MAC_ADDRESS123(ADDRESS) (((ADDRESS) == ETH_MAC_ADDRESS1) || \
-                                        ((ADDRESS) == ETH_MAC_ADDRESS2) || \
-                                        ((ADDRESS) == ETH_MAC_ADDRESS3))
-#define IS_ETH_MAC_ADDRESS_FILTER(FILTER) (((FILTER) == ETH_MAC_ADDRESSFILTER_SA) || \
-                                           ((FILTER) == ETH_MAC_ADDRESSFILTER_DA))
-#define IS_ETH_MAC_ADDRESS_MASK(MASK) (((MASK) == ETH_MAC_ADDRESSMASK_BYTE6) || \
-                                       ((MASK) == ETH_MAC_ADDRESSMASK_BYTE5) || \
-                                       ((MASK) == ETH_MAC_ADDRESSMASK_BYTE4) || \
-                                       ((MASK) == ETH_MAC_ADDRESSMASK_BYTE3) || \
-                                       ((MASK) == ETH_MAC_ADDRESSMASK_BYTE2) || \
-                                       ((MASK) == ETH_MAC_ADDRESSMASK_BYTE1))
-#define IS_ETH_DROP_TCPIP_CHECKSUM_FRAME(CMD) (((CMD) == ETH_DROPTCPIPCHECKSUMERRORFRAME_ENABLE) || \
-                                               ((CMD) == ETH_DROPTCPIPCHECKSUMERRORFRAME_DISABLE))
-#define IS_ETH_RECEIVE_STORE_FORWARD(CMD) (((CMD) == ETH_RECEIVESTOREFORWARD_ENABLE) || \
-                                           ((CMD) == ETH_RECEIVESTOREFORWARD_DISABLE))
-#define IS_ETH_FLUSH_RECEIVE_FRAME(CMD) (((CMD) == ETH_FLUSHRECEIVEDFRAME_ENABLE) || \
-                                         ((CMD) == ETH_FLUSHRECEIVEDFRAME_DISABLE))
-#define IS_ETH_TRANSMIT_STORE_FORWARD(CMD) (((CMD) == ETH_TRANSMITSTOREFORWARD_ENABLE) || \
-                                            ((CMD) == ETH_TRANSMITSTOREFORWARD_DISABLE))
-#define IS_ETH_TRANSMIT_THRESHOLD_CONTROL(THRESHOLD) (((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_64BYTES) || \
-                                                      ((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_128BYTES) || \
-                                                      ((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_192BYTES) || \
-                                                      ((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_256BYTES) || \
-                                                      ((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_40BYTES) || \
-                                                      ((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_32BYTES) || \
-                                                      ((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_24BYTES) || \
-                                                      ((THRESHOLD) == ETH_TRANSMITTHRESHOLDCONTROL_16BYTES))
-#define IS_ETH_FORWARD_ERROR_FRAMES(CMD) (((CMD) == ETH_FORWARDERRORFRAMES_ENABLE) || \
-                                          ((CMD) == ETH_FORWARDERRORFRAMES_DISABLE))
-#define IS_ETH_FORWARD_UNDERSIZED_GOOD_FRAMES(CMD) (((CMD) == ETH_FORWARDUNDERSIZEDGOODFRAMES_ENABLE) || \
-                                                    ((CMD) == ETH_FORWARDUNDERSIZEDGOODFRAMES_DISABLE))
-#define IS_ETH_RECEIVE_THRESHOLD_CONTROL(THRESHOLD) (((THRESHOLD) == ETH_RECEIVEDTHRESHOLDCONTROL_64BYTES) || \
-                                                     ((THRESHOLD) == ETH_RECEIVEDTHRESHOLDCONTROL_32BYTES) || \
-                                                     ((THRESHOLD) == ETH_RECEIVEDTHRESHOLDCONTROL_96BYTES) || \
-                                                     ((THRESHOLD) == ETH_RECEIVEDTHRESHOLDCONTROL_128BYTES))
-#define IS_ETH_SECOND_FRAME_OPERATE(CMD) (((CMD) == ETH_SECONDFRAMEOPERARTE_ENABLE) || \
-                                          ((CMD) == ETH_SECONDFRAMEOPERARTE_DISABLE))
-#define IS_ETH_ADDRESS_ALIGNED_BEATS(CMD) (((CMD) == ETH_ADDRESSALIGNEDBEATS_ENABLE) || \
-                                           ((CMD) == ETH_ADDRESSALIGNEDBEATS_DISABLE))
-#define IS_ETH_FIXED_BURST(CMD) (((CMD) == ETH_FIXEDBURST_ENABLE) || \
-                                 ((CMD) == ETH_FIXEDBURST_DISABLE))
-#define IS_ETH_RXDMA_BURST_LENGTH(LENGTH) (((LENGTH) == ETH_RXDMABURSTLENGTH_1BEAT) || \
-                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_2BEAT) || \
-                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_4BEAT) || \
-                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_8BEAT) || \
-                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_16BEAT) || \
-                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_32BEAT) || \
-                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_4XPBL_4BEAT) || \
-                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_4XPBL_8BEAT) || \
-                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_4XPBL_16BEAT) || \
-                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_4XPBL_32BEAT) || \
-                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_4XPBL_64BEAT) || \
-                                           ((LENGTH) == ETH_RXDMABURSTLENGTH_4XPBL_128BEAT))
-#define IS_ETH_TXDMA_BURST_LENGTH(LENGTH) (((LENGTH) == ETH_TXDMABURSTLENGTH_1BEAT) || \
-                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_2BEAT) || \
-                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_4BEAT) || \
-                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_8BEAT) || \
-                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_16BEAT) || \
-                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_32BEAT) || \
-                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_4XPBL_4BEAT) || \
-                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_4XPBL_8BEAT) || \
-                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_4XPBL_16BEAT) || \
-                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_4XPBL_32BEAT) || \
-                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_4XPBL_64BEAT) || \
-                                           ((LENGTH) == ETH_TXDMABURSTLENGTH_4XPBL_128BEAT))
-#define IS_ETH_DMA_DESC_SKIP_LENGTH(LENGTH) ((LENGTH) <= 0x1F)
-#define IS_ETH_DMA_ARBITRATION_ROUNDROBIN_RXTX(RATIO) (((RATIO) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_1_1) || \
-                                                       ((RATIO) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_2_1) || \
-                                                       ((RATIO) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_3_1) || \
-                                                       ((RATIO) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_4_1) || \
-                                                       ((RATIO) == ETH_DMAARBITRATION_RXPRIORTX))
-#define IS_ETH_DMATXDESC_GET_FLAG(FLAG) (((FLAG) == ETH_DMATXDESC_OWN) || \
-                                         ((FLAG) == ETH_DMATXDESC_IC) || \
-                                         ((FLAG) == ETH_DMATXDESC_LS) || \
-                                         ((FLAG) == ETH_DMATXDESC_FS) || \
-                                         ((FLAG) == ETH_DMATXDESC_DC) || \
-                                         ((FLAG) == ETH_DMATXDESC_DP) || \
-                                         ((FLAG) == ETH_DMATXDESC_TTSE) || \
-                                         ((FLAG) == ETH_DMATXDESC_TER) || \
-                                         ((FLAG) == ETH_DMATXDESC_TCH) || \
-                                         ((FLAG) == ETH_DMATXDESC_TTSS) || \
-                                         ((FLAG) == ETH_DMATXDESC_IHE) || \
-                                         ((FLAG) == ETH_DMATXDESC_ES) || \
-                                         ((FLAG) == ETH_DMATXDESC_JT) || \
-                                         ((FLAG) == ETH_DMATXDESC_FF) || \
-                                         ((FLAG) == ETH_DMATXDESC_PCE) || \
-                                         ((FLAG) == ETH_DMATXDESC_LCA) || \
-                                         ((FLAG) == ETH_DMATXDESC_NC) || \
-                                         ((FLAG) == ETH_DMATXDESC_LCO) || \
-                                         ((FLAG) == ETH_DMATXDESC_EC) || \
-                                         ((FLAG) == ETH_DMATXDESC_VF) || \
-                                         ((FLAG) == ETH_DMATXDESC_CC) || \
-                                         ((FLAG) == ETH_DMATXDESC_ED) || \
-                                         ((FLAG) == ETH_DMATXDESC_UF) || \
-                                         ((FLAG) == ETH_DMATXDESC_DB))
-#define IS_ETH_DMA_TXDESC_SEGMENT(SEGMENT) (((SEGMENT) == ETH_DMATXDESC_LASTSEGMENTS) || \
-                                            ((SEGMENT) == ETH_DMATXDESC_FIRSTSEGMENT))
-#define IS_ETH_DMA_TXDESC_CHECKSUM(CHECKSUM) (((CHECKSUM) == ETH_DMATXDESC_CHECKSUMBYPASS) || \
-                                              ((CHECKSUM) == ETH_DMATXDESC_CHECKSUMIPV4HEADER) || \
-                                              ((CHECKSUM) == ETH_DMATXDESC_CHECKSUMTCPUDPICMPSEGMENT) || \
-                                              ((CHECKSUM) == ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL))
-#define IS_ETH_DMATXDESC_BUFFER_SIZE(SIZE) ((SIZE) <= 0x1FFF)
-#define IS_ETH_DMARXDESC_GET_FLAG(FLAG) (((FLAG) == ETH_DMARXDESC_OWN) || \
-                                         ((FLAG) == ETH_DMARXDESC_AFM) || \
-                                         ((FLAG) == ETH_DMARXDESC_ES) || \
-                                         ((FLAG) == ETH_DMARXDESC_DE) || \
-                                         ((FLAG) == ETH_DMARXDESC_SAF) || \
-                                         ((FLAG) == ETH_DMARXDESC_LE) || \
-                                         ((FLAG) == ETH_DMARXDESC_OE) || \
-                                         ((FLAG) == ETH_DMARXDESC_VLAN) || \
-                                         ((FLAG) == ETH_DMARXDESC_FS) || \
-                                         ((FLAG) == ETH_DMARXDESC_LS) || \
-                                         ((FLAG) == ETH_DMARXDESC_IPV4HCE) || \
-                                         ((FLAG) == ETH_DMARXDESC_LC) || \
-                                         ((FLAG) == ETH_DMARXDESC_FT) || \
-                                         ((FLAG) == ETH_DMARXDESC_RWT) || \
-                                         ((FLAG) == ETH_DMARXDESC_RE) || \
-                                         ((FLAG) == ETH_DMARXDESC_DBE) || \
-                                         ((FLAG) == ETH_DMARXDESC_CE) || \
-                                         ((FLAG) == ETH_DMARXDESC_MAMPCE))
-#define IS_ETH_DMA_RXDESC_BUFFER(BUFFER) (((BUFFER) == ETH_DMARXDESC_BUFFER1) || \
-                                          ((BUFFER) == ETH_DMARXDESC_BUFFER2))
-#define IS_ETH_PMT_GET_FLAG(FLAG) (((FLAG) == ETH_PMT_FLAG_WUFR) || \
-                                   ((FLAG) == ETH_PMT_FLAG_MPR))
-#define IS_ETH_DMA_FLAG(FLAG) ((((FLAG) & (uint32_t)0xC7FE1800) == 0x00) && ((FLAG) != 0x00)) 
-#define IS_ETH_DMA_GET_FLAG(FLAG) (((FLAG) == ETH_DMA_FLAG_TST) || ((FLAG) == ETH_DMA_FLAG_PMT) || \
-                                   ((FLAG) == ETH_DMA_FLAG_MMC) || ((FLAG) == ETH_DMA_FLAG_DATATRANSFERERROR) || \
-                                   ((FLAG) == ETH_DMA_FLAG_READWRITEERROR) || ((FLAG) == ETH_DMA_FLAG_ACCESSERROR) || \
-                                   ((FLAG) == ETH_DMA_FLAG_NIS) || ((FLAG) == ETH_DMA_FLAG_AIS) || \
-                                   ((FLAG) == ETH_DMA_FLAG_ER) || ((FLAG) == ETH_DMA_FLAG_FBE) || \
-                                   ((FLAG) == ETH_DMA_FLAG_ET) || ((FLAG) == ETH_DMA_FLAG_RWT) || \
-                                   ((FLAG) == ETH_DMA_FLAG_RPS) || ((FLAG) == ETH_DMA_FLAG_RBU) || \
-                                   ((FLAG) == ETH_DMA_FLAG_R) || ((FLAG) == ETH_DMA_FLAG_TU) || \
-                                   ((FLAG) == ETH_DMA_FLAG_RO) || ((FLAG) == ETH_DMA_FLAG_TJT) || \
-                                   ((FLAG) == ETH_DMA_FLAG_TBU) || ((FLAG) == ETH_DMA_FLAG_TPS) || \
-                                   ((FLAG) == ETH_DMA_FLAG_T))
-#define IS_ETH_MAC_IT(IT) ((((IT) & (uint32_t)0xFFFFFDF1) == 0x00) && ((IT) != 0x00))
-#define IS_ETH_MAC_GET_IT(IT) (((IT) == ETH_MAC_IT_TST) || ((IT) == ETH_MAC_IT_MMCT) || \
-                               ((IT) == ETH_MAC_IT_MMCR) || ((IT) == ETH_MAC_IT_MMC) || \
-                               ((IT) == ETH_MAC_IT_PMT))
-#define IS_ETH_MAC_GET_FLAG(FLAG) (((FLAG) == ETH_MAC_FLAG_TST) || ((FLAG) == ETH_MAC_FLAG_MMCT) || \
-                                   ((FLAG) == ETH_MAC_FLAG_MMCR) || ((FLAG) == ETH_MAC_FLAG_MMC) || \
-                                   ((FLAG) == ETH_MAC_FLAG_PMT))
-#define IS_ETH_DMA_IT(IT) ((((IT) & (uint32_t)0xC7FE1800) == 0x00) && ((IT) != 0x00))
-#define IS_ETH_DMA_GET_IT(IT) (((IT) == ETH_DMA_IT_TST) || ((IT) == ETH_DMA_IT_PMT) || \
-                               ((IT) == ETH_DMA_IT_MMC) || ((IT) == ETH_DMA_IT_NIS) || \
-                               ((IT) == ETH_DMA_IT_AIS) || ((IT) == ETH_DMA_IT_ER) || \
-                               ((IT) == ETH_DMA_IT_FBE) || ((IT) == ETH_DMA_IT_ET) || \
-                               ((IT) == ETH_DMA_IT_RWT) || ((IT) == ETH_DMA_IT_RPS) || \
-                               ((IT) == ETH_DMA_IT_RBU) || ((IT) == ETH_DMA_IT_R) || \
-                               ((IT) == ETH_DMA_IT_TU) || ((IT) == ETH_DMA_IT_RO) || \
-                               ((IT) == ETH_DMA_IT_TJT) || ((IT) == ETH_DMA_IT_TBU) || \
-                               ((IT) == ETH_DMA_IT_TPS) || ((IT) == ETH_DMA_IT_T))
-#define IS_ETH_DMA_GET_OVERFLOW(OVERFLOW) (((OVERFLOW) == ETH_DMA_OVERFLOW_RXFIFOCOUNTER) || \
-                                           ((OVERFLOW) == ETH_DMA_OVERFLOW_MISSEDFRAMECOUNTER))
-#define IS_ETH_MMC_IT(IT) (((((IT) & (uint32_t)0xFFDF3FFF) == 0x00) || (((IT) & (uint32_t)0xEFFDFF9F) == 0x00)) && \
-                           ((IT) != 0x00))
-#define IS_ETH_MMC_GET_IT(IT) (((IT) == ETH_MMC_IT_TGF) || ((IT) == ETH_MMC_IT_TGFMSC) || \
-                               ((IT) == ETH_MMC_IT_TGFSC) || ((IT) == ETH_MMC_IT_RGUF) || \
-                               ((IT) == ETH_MMC_IT_RFAE) || ((IT) == ETH_MMC_IT_RFCE))
-#define IS_ETH_ENHANCED_DESCRIPTOR_FORMAT(CMD) (((CMD) == ETH_DMAENHANCEDDESCRIPTOR_ENABLE) || \
-                                                ((CMD) == ETH_DMAENHANCEDDESCRIPTOR_DISABLE))
-
-
-/**
-  * @}
   */
 
-/** @addtogroup ETH_Private_Defines
-  * @{
-  */
-/* Delay to wait when writing to some Ethernet registers */
-#define ETH_REG_WRITE_DELAY ((uint32_t)0x00000001U)
+/* Exported types ------------------------------------------------------------*/
+#ifndef ETH_TX_DESC_CNT
+#define ETH_TX_DESC_CNT         4U
+#endif /* ETH_TX_DESC_CNT */
 
-/* Ethernet Errors */
-#define  ETH_SUCCESS            ((uint32_t)0U)
-#define  ETH_ERROR              ((uint32_t)1U)
+#ifndef ETH_RX_DESC_CNT
+#define ETH_RX_DESC_CNT         4U
+#endif /* ETH_RX_DESC_CNT */
 
-/* Ethernet DMA Tx descriptors Collision Count Shift */
-#define  ETH_DMATXDESC_COLLISION_COUNTSHIFT         ((uint32_t)3U)
 
-/* Ethernet DMA Tx descriptors Buffer2 Size Shift */
-#define  ETH_DMATXDESC_BUFFER2_SIZESHIFT           ((uint32_t)16U)
-
-/* Ethernet DMA Rx descriptors Frame Length Shift */
-#define  ETH_DMARXDESC_FRAME_LENGTHSHIFT           ((uint32_t)16U)
-
-/* Ethernet DMA Rx descriptors Buffer2 Size Shift */
-#define  ETH_DMARXDESC_BUFFER2_SIZESHIFT           ((uint32_t)16U)
-
-/* Ethernet DMA Rx descriptors Frame length Shift */
-#define  ETH_DMARXDESC_FRAMELENGTHSHIFT            ((uint32_t)16)
-
-/* Ethernet MAC address offsets */
-#define ETH_MAC_ADDR_HBASE    (uint32_t)(ETH_MAC_BASE + (uint32_t)0x40U)  /* Ethernet MAC address high offset */
-#define ETH_MAC_ADDR_LBASE    (uint32_t)(ETH_MAC_BASE + (uint32_t)0x44U)  /* Ethernet MAC address low offset */
-
-/* Ethernet MACMIIAR register Mask */
-#define ETH_MACMIIAR_CR_MASK    ((uint32_t)0xFFFFFFE3U)
-
-/* Ethernet MACCR register Mask */
-#define ETH_MACCR_CLEAR_MASK    ((uint32_t)0xFF20810FU)  
-
-/* Ethernet MACFCR register Mask */
-#define ETH_MACFCR_CLEAR_MASK   ((uint32_t)0x0000FF41U)
-
-/* Ethernet DMAOMR register Mask */
-#define ETH_DMAOMR_CLEAR_MASK   ((uint32_t)0xF8DE3F23U)
-
-/* Ethernet Remote Wake-up frame register length */
-#define ETH_WAKEUP_REGISTER_LENGTH      8U
-
-/* Ethernet Missed frames counter Shift */
-#define  ETH_DMA_RX_OVERFLOW_MISSEDFRAMES_COUNTERSHIFT     17U
- /**
-  * @}
-  */
-
-/* Exported types ------------------------------------------------------------*/ 
+/*********************** Descriptors struct def section ************************/
 /** @defgroup ETH_Exported_Types ETH Exported Types
   * @{
   */
 
-/** 
-  * @brief  HAL State structures definition  
-  */ 
-typedef enum
-{
-  HAL_ETH_STATE_RESET             = 0x00U,    /*!< Peripheral not yet Initialized or disabled         */
-  HAL_ETH_STATE_READY             = 0x01U,    /*!< Peripheral Initialized and ready for use           */
-  HAL_ETH_STATE_BUSY              = 0x02U,    /*!< an internal process is ongoing                     */
-  HAL_ETH_STATE_BUSY_TX           = 0x12U,    /*!< Data Transmission process is ongoing               */
-  HAL_ETH_STATE_BUSY_RX           = 0x22U,    /*!< Data Reception process is ongoing                  */
-  HAL_ETH_STATE_BUSY_TX_RX        = 0x32U,    /*!< Data Transmission and Reception process is ongoing */
-  HAL_ETH_STATE_BUSY_WR           = 0x42U,    /*!< Write process is ongoing                           */
-  HAL_ETH_STATE_BUSY_RD           = 0x82U,    /*!< Read process is ongoing                            */
-  HAL_ETH_STATE_TIMEOUT           = 0x03U,    /*!< Timeout state                                      */
-  HAL_ETH_STATE_ERROR             = 0x04U     /*!< Reception process is ongoing                       */
-}HAL_ETH_StateTypeDef;
-
-/** 
-  * @brief  ETH Init Structure definition  
+/**
+  * @brief  ETH DMA Descriptor structure definition
   */
-
 typedef struct
 {
-  uint32_t             AutoNegotiation;           /*!< Selects or not the AutoNegotiation mode for the external PHY
-                                                           The AutoNegotiation allows an automatic setting of the Speed (10/100Mbps)
-                                                           and the mode (half/full-duplex).
-                                                           This parameter can be a value of @ref ETH_AutoNegotiation */
+  __IO uint32_t DESC0;
+  __IO uint32_t DESC1;
+  __IO uint32_t DESC2;
+  __IO uint32_t DESC3;
+  __IO uint32_t DESC4;
+  __IO uint32_t DESC5;
+  __IO uint32_t DESC6;
+  __IO uint32_t DESC7;
+  uint32_t BackupAddr0; /* used to store rx buffer 1 address */
+  uint32_t BackupAddr1; /* used to store rx buffer 2 address */
+} ETH_DMADescTypeDef;
+/**
+  *
+  */
 
-  uint32_t             Speed;                     /*!< Sets the Ethernet speed: 10/100 Mbps.
+/**
+  * @brief  ETH Buffers List structure definition
+  */
+typedef struct __ETH_BufferTypeDef
+{
+  uint8_t *buffer;                /*<! buffer address */
+
+  uint32_t len;                   /*<! buffer length */
+
+  struct __ETH_BufferTypeDef *next; /*<! Pointer to the next buffer in the list */
+} ETH_BufferTypeDef;
+/**
+  *
+  */
+
+/**
+  * @brief  DMA Transmit Descriptors Wrapper structure definition
+  */
+typedef struct
+{
+  uint32_t  TxDesc[ETH_TX_DESC_CNT];        /*<! Tx DMA descriptors addresses */
+
+  uint32_t  CurTxDesc;                      /*<! Current Tx descriptor index for packet transmission */
+
+  uint32_t *PacketAddress[ETH_TX_DESC_CNT];  /*<! Ethernet packet addresses array */
+
+  uint32_t *CurrentPacketAddress;           /*<! Current transmit NX_PACKET addresses */
+
+  uint32_t BuffersInUse;                   /*<! Buffers in Use */
+
+  uint32_t releaseIndex;                  /*<! Release index */
+} ETH_TxDescListTypeDef;
+/**
+  *
+  */
+
+/**
+  * @brief  Transmit Packet Configuration structure definition
+  */
+typedef struct
+{
+  uint32_t Attributes;              /*!< Tx packet HW features capabilities.
+                                         This parameter can be a combination of @ref ETH_Tx_Packet_Attributes*/
+
+  uint32_t Length;                  /*!< Total packet length   */
+
+  ETH_BufferTypeDef *TxBuffer;      /*!< Tx buffers pointers */
+
+  uint32_t SrcAddrCtrl;             /*!< Specifies the source address insertion control.
+                                         This parameter can be a value of @ref ETH_Tx_Packet_Source_Addr_Control */
+
+  uint32_t CRCPadCtrl;             /*!< Specifies the CRC and Pad insertion and replacement control.
+                                        This parameter can be a value of @ref ETH_Tx_Packet_CRC_Pad_Control  */
+
+  uint32_t ChecksumCtrl;           /*!< Specifies the checksum insertion control.
+                                        This parameter can be a value of @ref ETH_Tx_Packet_Checksum_Control  */
+
+  uint32_t MaxSegmentSize;         /*!< Sets TCP maximum segment size only when TCP segmentation is enabled.
+                                        This parameter can be a value from 0x0 to 0x3FFF */
+
+  uint32_t PayloadLen;             /*!< Sets Total payload length only when TCP segmentation is enabled.
+                                        This parameter can be a value from 0x0 to 0x3FFFF */
+
+  uint32_t TCPHeaderLen;           /*!< Sets TCP header length only when TCP segmentation is enabled.
+                                        This parameter can be a value from 0x5 to 0xF */
+
+  uint32_t VlanTag;                /*!< Sets VLAN Tag only when VLAN is enabled.
+                                        This parameter can be a value from 0x0 to 0xFFFF*/
+
+  uint32_t VlanCtrl;               /*!< Specifies VLAN Tag insertion control only when VLAN is enabled.
+                                        This parameter can be a value of @ref ETH_Tx_Packet_VLAN_Control */
+
+  uint32_t InnerVlanTag;           /*!< Sets Inner VLAN Tag only when Inner VLAN is enabled.
+                                        This parameter can be a value from 0x0 to 0x3FFFF */
+
+  uint32_t InnerVlanCtrl;          /*!< Specifies Inner VLAN Tag insertion control only when Inner VLAN is enabled.
+                                        This parameter can be a value of @ref ETH_Tx_Packet_Inner_VLAN_Control   */
+
+  void *pData;                     /*!< Specifies Application packet pointer to save   */
+
+} ETH_TxPacketConfig;
+/**
+  *
+  */
+
+/**
+  * @brief  ETH Timestamp structure definition
+  */
+typedef struct
+{
+  uint32_t TimeStampLow;
+  uint32_t TimeStampHigh;
+
+} ETH_TimeStampTypeDef;
+/**
+  *
+  */
+
+/**
+  * @brief  ETH Timeupdate structure definition
+  */
+typedef struct
+{
+  uint32_t Seconds;
+  uint32_t NanoSeconds;
+} ETH_TimeTypeDef;
+/**
+  *
+  */
+
+/**
+  * @brief  DMA Receive Descriptors Wrapper structure definition
+  */
+typedef struct
+{
+  uint32_t RxDesc[ETH_RX_DESC_CNT];     /*<! Rx DMA descriptors addresses. */
+
+  uint32_t ItMode;                      /*<! If 1, DMA will generate the Rx complete interrupt.
+                                             If 0, DMA will not generate the Rx complete interrupt. */
+
+  uint32_t RxDescIdx;                 /*<! Current Rx descriptor. */
+
+  uint32_t RxDescCnt;                 /*<! Number of descriptors . */
+
+  uint32_t RxDataLength;              /*<! Received Data Length. */
+
+  uint32_t RxBuildDescIdx;            /*<! Current Rx Descriptor for building descriptors. */
+
+  uint32_t RxBuildDescCnt;            /*<! Number of Rx Descriptors awaiting building. */
+
+  uint32_t pRxLastRxDesc;             /*<! Last received descriptor. */
+
+  ETH_TimeStampTypeDef TimeStamp;     /*<! Time Stamp Low value for receive. */
+
+  void *pRxStart;                     /*<! Pointer to the first buff. */
+
+  void *pRxEnd;                       /*<! Pointer to the last buff. */
+
+} ETH_RxDescListTypeDef;
+/**
+  *
+  */
+
+/**
+  * @brief  ETH MAC Configuration Structure definition
+  */
+typedef struct
+{
+  uint32_t
+  SourceAddrControl;           /*!< Selects the Source Address Insertion or Replacement Control.
+                                                     This parameter can be a value of @ref ETH_Source_Addr_Control */
+
+  FunctionalState
+  ChecksumOffload;             /*!< Enables or Disable the checksum checking for received packet payloads TCP, UDP or ICMP headers */
+
+  uint32_t         InterPacketGapVal;           /*!< Sets the minimum IPG between Packet during transmission.
+                                                     This parameter can be a value of @ref ETH_Inter_Packet_Gap */
+
+  FunctionalState  GiantPacketSizeLimitControl; /*!< Enables or disables the Giant Packet Size Limit Control. */
+
+  FunctionalState  Support2KPacket;             /*!< Enables or disables the IEEE 802.3as Support for 2K length Packets */
+
+  FunctionalState  CRCStripTypePacket;          /*!< Enables or disables the CRC stripping for Type packets.*/
+
+  FunctionalState  AutomaticPadCRCStrip;        /*!< Enables or disables  the Automatic MAC Pad/CRC Stripping.*/
+
+  FunctionalState  Watchdog;                    /*!< Enables or disables the Watchdog timer on Rx path.*/
+
+  FunctionalState  Jabber;                      /*!< Enables or disables Jabber timer on Tx path.*/
+
+  FunctionalState  JumboPacket;                 /*!< Enables or disables receiving Jumbo Packet
+                                                           When enabled, the MAC allows jumbo packets of 9,018 bytes
+                                                           without reporting a giant packet error */
+
+  uint32_t         Speed;                       /*!< Sets the Ethernet speed: 10/100 Mbps.
                                                            This parameter can be a value of @ref ETH_Speed */
 
-  uint32_t             DuplexMode;                /*!< Selects the MAC duplex mode: Half-Duplex or Full-Duplex mode
+  uint32_t         DuplexMode;                  /*!< Selects the MAC duplex mode: Half-Duplex or Full-Duplex mode
                                                            This parameter can be a value of @ref ETH_Duplex_Mode */
-  
-  uint16_t             PhyAddress;                /*!< Ethernet PHY address.
-                                                           This parameter must be a number between Min_Data = 0 and Max_Data = 32 */
-  
-  uint8_t             *MACAddr;                   /*!< MAC Address of used Hardware: must be pointer on an array of 6 bytes */
-  
-  uint32_t             RxMode;                    /*!< Selects the Ethernet Rx mode: Polling mode, Interrupt mode.
-                                                           This parameter can be a value of @ref ETH_Rx_Mode */
-  
-  uint32_t             ChecksumMode;              /*!< Selects if the checksum is check by hardware or by software. 
-                                                         This parameter can be a value of @ref ETH_Checksum_Mode */
-  
-  uint32_t             MediaInterface    ;               /*!< Selects the media-independent interface or the reduced media-independent interface. 
-                                                         This parameter can be a value of @ref ETH_Media_Interface */
 
-} ETH_InitTypeDef;
+  FunctionalState  LoopbackMode;                /*!< Enables or disables the loopback mode */
 
+  FunctionalState
+  CarrierSenseBeforeTransmit;  /*!< Enables or disables the Carrier Sense Before Transmission in Full Duplex Mode. */
 
- /** 
-  * @brief  ETH MAC Configuration Structure definition  
+  FunctionalState  ReceiveOwn;                  /*!< Enables or disables the Receive Own in Half Duplex mode. */
+
+  FunctionalState
+  CarrierSenseDuringTransmit;  /*!< Enables or disables the Carrier Sense During Transmission in the Half Duplex mode */
+
+  FunctionalState
+  RetryTransmission;           /*!< Enables or disables the MAC retry transmission, when a collision occurs in Half Duplex mode.*/
+
+  uint32_t         BackOffLimit;                /*!< Selects the BackOff limit value.
+                                                        This parameter can be a value of @ref ETH_Back_Off_Limit */
+
+  FunctionalState
+  DeferralCheck;               /*!< Enables or disables the deferral check function in Half Duplex mode. */
+
+  uint32_t
+  PreambleLength;              /*!< Selects or not the Preamble Length for Transmit packets (Full Duplex mode).
+                                                           This parameter can be a value of @ref ETH_Preamble_Length */
+
+  FunctionalState
+  UnicastSlowProtocolPacketDetect;   /*!< Enable or disables the Detection of Slow Protocol Packets with unicast address. */
+
+  FunctionalState  SlowProtocolDetect;          /*!< Enable or disables the Slow Protocol Detection. */
+
+  FunctionalState  CRCCheckingRxPackets;        /*!< Enable or disables the CRC Checking for Received Packets. */
+
+  uint32_t
+  GiantPacketSizeLimit;        /*!< Specifies the packet size that the MAC will declare it as Giant, If it's size is
+                                                    greater than the value programmed in this field in units of bytes
+                                                    This parameter must be a number between
+                                                    Min_Data = 0x618 (1518 byte) and Max_Data = 0x3FFF (32 Kbyte). */
+
+  FunctionalState  ExtendedInterPacketGap;      /*!< Enable or disables the extended inter packet gap. */
+
+  uint32_t         ExtendedInterPacketGapVal;   /*!< Sets the Extended IPG between Packet during transmission.
+                                                           This parameter can be a value from 0x0 to 0xFF */
+
+  FunctionalState  ProgrammableWatchdog;        /*!< Enable or disables the Programmable Watchdog.*/
+
+  uint32_t         WatchdogTimeout;             /*!< This field is used as watchdog timeout for a received packet
+                                                        This parameter can be a value of @ref ETH_Watchdog_Timeout */
+
+  uint32_t
+  PauseTime;                   /*!< This field holds the value to be used in the Pause Time field in the transmit control packet.
+                                                   This parameter must be a number between
+                                                   Min_Data = 0x0 and Max_Data = 0xFFFF.*/
+
+  FunctionalState
+  ZeroQuantaPause;             /*!< Enable or disables the automatic generation of Zero Quanta Pause Control packets.*/
+
+  uint32_t
+  PauseLowThreshold;           /*!< This field configures the threshold of the PAUSE to be checked for automatic retransmission of PAUSE Packet.
+                                                   This parameter can be a value of @ref ETH_Pause_Low_Threshold */
+
+  FunctionalState
+  TransmitFlowControl;         /*!< Enables or disables the MAC to transmit Pause packets in Full Duplex mode
+                                                   or the MAC back pressure operation in Half Duplex mode */
+
+  FunctionalState
+  UnicastPausePacketDetect;    /*!< Enables or disables the MAC to detect Pause packets with unicast address of the station */
+
+  FunctionalState  ReceiveFlowControl;          /*!< Enables or disables the MAC to decodes the received Pause packet
+                                                  and disables its transmitter for a specified (Pause) time */
+
+  uint32_t         TransmitQueueMode;           /*!< Specifies the Transmit Queue operating mode.
+                                                      This parameter can be a value of @ref ETH_Transmit_Mode */
+
+  uint32_t         ReceiveQueueMode;            /*!< Specifies the Receive Queue operating mode.
+                                                             This parameter can be a value of @ref ETH_Receive_Mode */
+
+  FunctionalState  DropTCPIPChecksumErrorPacket; /*!< Enables or disables Dropping of TCPIP Checksum Error Packets. */
+
+  FunctionalState  ForwardRxErrorPacket;        /*!< Enables or disables  forwarding Error Packets. */
+
+  FunctionalState  ForwardRxUndersizedGoodPacket;  /*!< Enables or disables  forwarding Undersized Good Packets.*/
+} ETH_MACConfigTypeDef;
+/**
+  *
   */
 
-typedef struct
-{
-  uint32_t             Watchdog;                  /*!< Selects or not the Watchdog timer
-                                                           When enabled, the MAC allows no more then 2048 bytes to be received.
-                                                           When disabled, the MAC can receive up to 16384 bytes.
-                                                           This parameter can be a value of @ref ETH_Watchdog */  
-
-  uint32_t             Jabber;                    /*!< Selects or not Jabber timer
-                                                           When enabled, the MAC allows no more then 2048 bytes to be sent.
-                                                           When disabled, the MAC can send up to 16384 bytes.
-                                                           This parameter can be a value of @ref ETH_Jabber */
-
-  uint32_t             InterFrameGap;             /*!< Selects the minimum IFG between frames during transmission.
-                                                           This parameter can be a value of @ref ETH_Inter_Frame_Gap */   
-
-  uint32_t             CarrierSense;              /*!< Selects or not the Carrier Sense.
-                                                           This parameter can be a value of @ref ETH_Carrier_Sense */
-
-  uint32_t             ReceiveOwn;                /*!< Selects or not the ReceiveOwn,
-                                                           ReceiveOwn allows the reception of frames when the TX_EN signal is asserted
-                                                           in Half-Duplex mode.
-                                                           This parameter can be a value of @ref ETH_Receive_Own */  
-
-  uint32_t             LoopbackMode;              /*!< Selects or not the internal MAC MII Loopback mode.
-                                                           This parameter can be a value of @ref ETH_Loop_Back_Mode */  
-
-  uint32_t             ChecksumOffload;           /*!< Selects or not the IPv4 checksum checking for received frame payloads' TCP/UDP/ICMP headers.
-                                                           This parameter can be a value of @ref ETH_Checksum_Offload */    
-
-  uint32_t             RetryTransmission;         /*!< Selects or not the MAC attempt retries transmission, based on the settings of BL,
-                                                           when a collision occurs (Half-Duplex mode).
-                                                           This parameter can be a value of @ref ETH_Retry_Transmission */
-
-  uint32_t             AutomaticPadCRCStrip;      /*!< Selects or not the Automatic MAC Pad/CRC Stripping.
-                                                           This parameter can be a value of @ref ETH_Automatic_Pad_CRC_Strip */ 
-
-  uint32_t             BackOffLimit;              /*!< Selects the BackOff limit value.
-                                                           This parameter can be a value of @ref ETH_Back_Off_Limit */
-
-  uint32_t             DeferralCheck;             /*!< Selects or not the deferral check function (Half-Duplex mode).
-                                                           This parameter can be a value of @ref ETH_Deferral_Check */                                                                                                        
-
-  uint32_t             ReceiveAll;                /*!< Selects or not all frames reception by the MAC (No filtering).
-                                                           This parameter can be a value of @ref ETH_Receive_All */   
-
-  uint32_t             SourceAddrFilter;          /*!< Selects the Source Address Filter mode.                                                           
-                                                           This parameter can be a value of @ref ETH_Source_Addr_Filter */                  
-
-  uint32_t             PassControlFrames;         /*!< Sets the forwarding mode of the control frames (including unicast and multicast PAUSE frames)                                                          
-                                                           This parameter can be a value of @ref ETH_Pass_Control_Frames */ 
-
-  uint32_t             BroadcastFramesReception;  /*!< Selects or not the reception of Broadcast Frames.
-                                                           This parameter can be a value of @ref ETH_Broadcast_Frames_Reception */
-
-  uint32_t             DestinationAddrFilter;     /*!< Sets the destination filter mode for both unicast and multicast frames.
-                                                           This parameter can be a value of @ref ETH_Destination_Addr_Filter */ 
-
-  uint32_t             PromiscuousMode;           /*!< Selects or not the Promiscuous Mode
-                                                           This parameter can be a value of @ref ETH_Promiscuous_Mode */
-
-  uint32_t             MulticastFramesFilter;     /*!< Selects the Multicast Frames filter mode: None/HashTableFilter/PerfectFilter/PerfectHashTableFilter.
-                                                           This parameter can be a value of @ref ETH_Multicast_Frames_Filter */ 
-
-  uint32_t             UnicastFramesFilter;       /*!< Selects the Unicast Frames filter mode: HashTableFilter/PerfectFilter/PerfectHashTableFilter.
-                                                           This parameter can be a value of @ref ETH_Unicast_Frames_Filter */ 
-
-  uint32_t             HashTableHigh;             /*!< This field holds the higher 32 bits of Hash table.
-                                                           This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF */
-
-  uint32_t             HashTableLow;              /*!< This field holds the lower 32 bits of Hash table.
-                                                           This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF  */    
-
-  uint32_t             PauseTime;                 /*!< This field holds the value to be used in the Pause Time field in the transmit control frame. 
-                                                           This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFF */
-
-  uint32_t             ZeroQuantaPause;           /*!< Selects or not the automatic generation of Zero-Quanta Pause Control frames.
-                                                           This parameter can be a value of @ref ETH_Zero_Quanta_Pause */  
-
-  uint32_t             PauseLowThreshold;         /*!< This field configures the threshold of the PAUSE to be checked for
-                                                           automatic retransmission of PAUSE Frame.
-                                                           This parameter can be a value of @ref ETH_Pause_Low_Threshold */
-                                                           
-  uint32_t             UnicastPauseFrameDetect;   /*!< Selects or not the MAC detection of the Pause frames (with MAC Address0
-                                                           unicast address and unique multicast address).
-                                                           This parameter can be a value of @ref ETH_Unicast_Pause_Frame_Detect */  
-
-  uint32_t             ReceiveFlowControl;        /*!< Enables or disables the MAC to decode the received Pause frame and
-                                                           disable its transmitter for a specified time (Pause Time)
-                                                           This parameter can be a value of @ref ETH_Receive_Flow_Control */
-
-  uint32_t             TransmitFlowControl;       /*!< Enables or disables the MAC to transmit Pause frames (Full-Duplex mode)
-                                                           or the MAC back-pressure operation (Half-Duplex mode)
-                                                           This parameter can be a value of @ref ETH_Transmit_Flow_Control */     
-
-  uint32_t             VLANTagComparison;         /*!< Selects the 12-bit VLAN identifier or the complete 16-bit VLAN tag for
-                                                           comparison and filtering.
-                                                           This parameter can be a value of @ref ETH_VLAN_Tag_Comparison */ 
-
-  uint32_t             VLANTagIdentifier;         /*!< Holds the VLAN tag identifier for receive frames */
-
-} ETH_MACInitTypeDef;
-
-
-/** 
-  * @brief  ETH DMA Configuration Structure definition  
+/**
+  * @brief  ETH DMA Configuration Structure definition
   */
-
 typedef struct
 {
- uint32_t              DropTCPIPChecksumErrorFrame; /*!< Selects or not the Dropping of TCP/IP Checksum Error Frames.
-                                                             This parameter can be a value of @ref ETH_Drop_TCP_IP_Checksum_Error_Frame */ 
+  uint32_t        DMAArbitration;          /*!< Sets the arbitration scheme between DMA Tx and Rx
+                                                         This parameter can be a value of @ref ETH_DMA_Arbitration */
 
-  uint32_t             ReceiveStoreForward;         /*!< Enables or disables the Receive store and forward mode.
-                                                             This parameter can be a value of @ref ETH_Receive_Store_Forward */ 
+  FunctionalState AddressAlignedBeats;     /*!< Enables or disables the AHB Master interface address aligned
+                                                            burst transfers on Read and Write channels  */
 
-  uint32_t             FlushReceivedFrame;          /*!< Enables or disables the flushing of received frames.
-                                                             This parameter can be a value of @ref ETH_Flush_Received_Frame */ 
+  uint32_t        BurstMode;               /*!< Sets the AHB Master interface burst transfers.
+                                                     This parameter can be a value of @ref ETH_Burst_Mode */
 
-  uint32_t             TransmitStoreForward;        /*!< Enables or disables Transmit store and forward mode.
-                                                             This parameter can be a value of @ref ETH_Transmit_Store_Forward */ 
+  FunctionalState      DropTCPIPChecksumErrorFrame; /*!< Selects or not the Dropping of TCP/IP Checksum Error Frames */
+
+  FunctionalState      ReceiveStoreForward;         /*!< Enables or disables the Receive store and forward mode */
+
+  FunctionalState      TransmitStoreForward;        /*!< Enables or disables Transmit store and forward mode */
+
+
+  uint32_t
+  TxDMABurstLength;        /*!< Indicates the maximum number of beats to be transferred in one Tx DMA transaction.
+                                                     This parameter can be a value of @ref ETH_Tx_DMA_Burst_Length */
 
   uint32_t             TransmitThresholdControl;    /*!< Selects or not the Transmit Threshold Control.
-                                                             This parameter can be a value of @ref ETH_Transmit_Threshold_Control */
+                                                             This parameter can be a value of
+                                                             @ref ETH_Transmit_Threshold_Control */
 
-  uint32_t             ForwardErrorFrames;          /*!< Selects or not the forward to the DMA of erroneous frames.
-                                                             This parameter can be a value of @ref ETH_Forward_Error_Frames */
+  uint32_t
+  RxDMABurstLength;        /*!< Indicates the maximum number of beats to be transferred in one Rx DMA transaction.
+                                                    This parameter can be a value of @ref ETH_Rx_DMA_Burst_Length */
 
-  uint32_t             ForwardUndersizedGoodFrames; /*!< Enables or disables the Rx FIFO to forward Undersized frames (frames with no Error
-                                                             and length less than 64 bytes) including pad-bytes and CRC)
-                                                             This parameter can be a value of @ref ETH_Forward_Undersized_Good_Frames */
+  FunctionalState      ForwardErrorFrames;          /*!< Selects or not the forward to the DMA of erroneous frames */
+  FunctionalState FlushRxPacket;           /*!< Enables or disables the Rx Packet Flush */
+
+  FunctionalState
+  ForwardUndersizedGoodFrames; /*!< Enables or disables the Rx FIFO to forward Undersized frames (frames with no Error
+                                                             and length less than 64 bytes)
+                                                             including pad-bytes and CRC) */
 
   uint32_t             ReceiveThresholdControl;     /*!< Selects the threshold level of the Receive FIFO.
-                                                             This parameter can be a value of @ref ETH_Receive_Threshold_Control */
+                                                             This parameter can be a value of
+                                                             @ref ETH_Receive_Threshold_Control */
 
-  uint32_t             SecondFrameOperate;          /*!< Selects or not the Operate on second frame mode, which allows the DMA to process a second
-                                                             frame of Transmit data even before obtaining the status for the first frame.
-                                                             This parameter can be a value of @ref ETH_Second_Frame_Operate */
+  FunctionalState
+  SecondFrameOperate;          /*!< Selects or not the Operate on second frame mode, which allows the DMA to process a second
+                                                             frame of Transmit data even before obtaining
+                                                             the status for the first frame */
 
-  uint32_t             AddressAlignedBeats;         /*!< Enables or disables the Address Aligned Beats.
-                                                             This parameter can be a value of @ref ETH_Address_Aligned_Beats */
+  FunctionalState      EnhancedDescriptorFormat;    /*!< Enables the enhanced descriptor format */
 
-  uint32_t             FixedBurst;                  /*!< Enables or disables the AHB Master interface fixed burst transfers.
-                                                             This parameter can be a value of @ref ETH_Fixed_Burst */
-                       
-  uint32_t             RxDMABurstLength;            /*!< Indicates the maximum number of beats to be transferred in one Rx DMA transaction.
-                                                             This parameter can be a value of @ref ETH_Rx_DMA_Burst_Length */ 
-
-  uint32_t             TxDMABurstLength;            /*!< Indicates the maximum number of beats to be transferred in one Tx DMA transaction.
-                                                             This parameter can be a value of @ref ETH_Tx_DMA_Burst_Length */
-  
-  uint32_t             EnhancedDescriptorFormat;    /*!< Enables the enhanced descriptor format.
-                                                             This parameter can be a value of @ref ETH_DMA_Enhanced_descriptor_format */
-
-  uint32_t             DescriptorSkipLength;        /*!< Specifies the number of word to skip between two unchained descriptors (Ring mode)
-                                                             This parameter must be a number between Min_Data = 0 and Max_Data = 32 */                                                             
-
-  uint32_t             DMAArbitration;              /*!< Selects the DMA Tx/Rx arbitration.
-                                                             This parameter can be a value of @ref ETH_DMA_Arbitration */  
-} ETH_DMAInitTypeDef;
-
-
-/** 
-  * @brief  ETH DMA Descriptors data structure definition
-  */ 
-
-typedef struct  
-{
-  __IO uint32_t   Status;           /*!< Status */
-  
-  uint32_t   ControlBufferSize;     /*!< Control and Buffer1, Buffer2 lengths */
-  
-  uint32_t   Buffer1Addr;           /*!< Buffer1 address pointer */
-  
-  uint32_t   Buffer2NextDescAddr;   /*!< Buffer2 or next descriptor address pointer */
-  
-  /*!< Enhanced Ethernet DMA PTP Descriptors */
-  uint32_t   ExtendedStatus;        /*!< Extended status for PTP receive descriptor */
-  
-  uint32_t   Reserved1;             /*!< Reserved */
-  
-  uint32_t   TimeStampLow;          /*!< Time Stamp Low value for transmit and receive */
-  
-  uint32_t   TimeStampHigh;         /*!< Time Stamp High value for transmit and receive */
-
-} ETH_DMADescTypeDef;
-
-
-/** 
-  * @brief  Received Frame Information structure definition
-  */ 
-typedef struct  
-{
-  ETH_DMADescTypeDef *FSRxDesc;          /*!< First Segment Rx Desc */
-  
-  ETH_DMADescTypeDef *LSRxDesc;          /*!< Last Segment Rx Desc */
-  
-  uint32_t  SegCount;                    /*!< Segment count */
-  
-  uint32_t length;                       /*!< Frame length */
-  
-  uint32_t buffer;                       /*!< Frame buffer */
-
-} ETH_DMARxFrameInfos;
-
-
-/** 
-  * @brief  ETH Handle Structure definition  
+  uint32_t
+  DescriptorSkipLength;        /*!< Specifies the number of word to skip between two unchained descriptors (Ring mode)
+                                                             This parameter must be a number between
+                                                             Min_Data = 0 and Max_Data = 32 */
+} ETH_DMAConfigTypeDef;
+/**
+  *
   */
-  
+
+/**
+  * @brief  HAL ETH Media Interfaces enum definition
+  */
+typedef enum
+{
+  HAL_ETH_MII_MODE             = 0x00U,   /*!<  Media Independent Interface               */
+  HAL_ETH_RMII_MODE            = ((uint32_t)SYSCFG_PMC_MII_RMII_SEL)    /*!<   Reduced Media Independent Interface       */
+} ETH_MediaInterfaceTypeDef;
+/**
+  *
+  */
+
+/**
+  * @brief  HAL ETH PTP Update type enum definition
+  */
+typedef enum
+{
+  HAL_ETH_PTP_POSITIVE_UPDATE   = 0x00000000U,   /*!<  PTP positive time update       */
+  HAL_ETH_PTP_NEGATIVE_UPDATE   = 0x00000001U   /*!<  PTP negative time update       */
+} ETH_PtpUpdateTypeDef;
+/**
+  *
+  */
+
+/**
+  * @brief  ETH Init Structure definition
+  */
+typedef struct
+{
+
+  uint8_t
+  *MACAddr;                  /*!< MAC Address of used Hardware: must be pointer on an array of 6 bytes */
+
+  ETH_MediaInterfaceTypeDef   MediaInterface;            /*!< Selects the MII interface or the RMII interface. */
+
+  ETH_DMADescTypeDef
+  *TxDesc;                   /*!< Provides the address of the first DMA Tx descriptor in the list */
+
+  ETH_DMADescTypeDef
+  *RxDesc;                   /*!< Provides the address of the first DMA Rx descriptor in the list */
+
+  uint32_t                    RxBuffLen;                 /*!< Provides the length of Rx buffers size */
+
+} ETH_InitTypeDef;
+/**
+  *
+  */
+
+/**
+  * @brief  ETH PTP Init Structure definition
+  */
+typedef struct
+{
+  uint32_t                    Timestamp;                    /*!< Enable Timestamp */
+  uint32_t                    TimestampUpdateMode;          /*!< Fine or Coarse Timestamp Update */
+  uint32_t                    TimestampInitialize;          /*!< Initialize Timestamp */
+  uint32_t                    TimestampUpdate;              /*!< Timestamp Update */
+  uint32_t                    TimestampAddendUpdate;        /*!< Timestamp Addend Update */
+  uint32_t                    TimestampAll;                 /*!< Enable Timestamp for All Packets */
+  uint32_t                    TimestampRolloverMode;        /*!< Timestamp Digital or Binary Rollover Control */
+  uint32_t                    TimestampV2;                  /*!< Enable PTP Packet Processing for Version 2 Format */
+  uint32_t                    TimestampEthernet;            /*!< Enable Processing of PTP over Ethernet Packets */
+  uint32_t                    TimestampIPv6;                /*!< Enable Processing of PTP Packets Sent over IPv6-UDP */
+  uint32_t                    TimestampIPv4;                /*!< Enable Processing of PTP Packets Sent over IPv4-UDP */
+  uint32_t                    TimestampEvent;               /*!< Enable Timestamp Snapshot for Event Messages */
+  uint32_t                    TimestampMaster;              /*!< Enable Timestamp Snapshot for Event Messages */
+  uint32_t                    TimestampFilter;              /*!< Enable MAC Address for PTP Packet Filtering */
+  uint32_t                    TimestampClockType;           /*!< Time stamp clock node type */
+  uint32_t                    TimestampAddend;              /*!< Timestamp addend value */
+  uint32_t                    TimestampSubsecondInc;        /*!< Subsecond Increment */
+
+} ETH_PTP_ConfigTypeDef;
+/**
+  *
+  */
+
+/**
+  * @brief  HAL State structures definition
+  */
+typedef uint32_t HAL_ETH_StateTypeDef;
+/**
+  *
+  */
+
+/**
+  * @brief  HAL ETH Rx Get Buffer Function definition
+  */
+typedef  void (*pETH_rxAllocateCallbackTypeDef)(uint8_t **buffer);  /*!< pointer to an ETH Rx Get Buffer Function */
+/**
+  *
+  */
+
+/**
+  * @brief  HAL ETH Rx Set App Data Function definition
+  */
+typedef  void (*pETH_rxLinkCallbackTypeDef)(void **pStart, void **pEnd, uint8_t *buff,
+                                            uint16_t Length); /*!< pointer to an ETH Rx Set App Data Function */
+/**
+  *
+  */
+
+/**
+  * @brief  HAL ETH Tx Free Function definition
+  */
+typedef  void (*pETH_txFreeCallbackTypeDef)(uint32_t *buffer);  /*!< pointer to an ETH Tx Free function */
+/**
+  *
+  */
+
+/**
+  * @brief  HAL ETH Tx Free Function definition
+  */
+typedef  void (*pETH_txPtpCallbackTypeDef)(uint32_t *buffer,
+                                           ETH_TimeStampTypeDef *timestamp);  /*!< pointer to an ETH Tx Free function */
+/**
+  *
+  */
+
+/**
+  * @brief  ETH Handle Structure definition
+  */
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
 typedef struct __ETH_HandleTypeDef
 #else
 typedef struct
-#endif
+#endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
 {
-  ETH_TypeDef                *Instance;     /*!< Register base address       */
-  
-  ETH_InitTypeDef            Init;          /*!< Ethernet Init Configuration */
-  
-  uint32_t                   LinkStatus;    /*!< Ethernet link status        */
-  
-  ETH_DMADescTypeDef         *RxDesc;       /*!< Rx descriptor to Get        */
-  
-  ETH_DMADescTypeDef         *TxDesc;       /*!< Tx descriptor to Set        */
-  
-  ETH_DMARxFrameInfos        RxFrameInfos;  /*!< last Rx frame infos         */
-  
-  __IO HAL_ETH_StateTypeDef  State;         /*!< ETH communication state     */
-  
-  HAL_LockTypeDef            Lock;          /*!< ETH Lock                    */
+  ETH_TypeDef                *Instance;                 /*!< Register base address       */
 
-  #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
+  ETH_InitTypeDef            Init;                      /*!< Ethernet Init Configuration */
 
-  void    (* TxCpltCallback)     ( struct __ETH_HandleTypeDef * heth);  /*!< ETH Tx Complete Callback   */
-  void    (* RxCpltCallback)     ( struct __ETH_HandleTypeDef * heth);  /*!< ETH Rx  Complete Callback   */
-  void    (* DMAErrorCallback)   ( struct __ETH_HandleTypeDef * heth);  /*!< DMA Error Callback      */
-  void    (* MspInitCallback)    ( struct __ETH_HandleTypeDef * heth);  /*!< ETH Msp Init callback       */
-  void    (* MspDeInitCallback)  ( struct __ETH_HandleTypeDef * heth);  /*!< ETH Msp DeInit callback     */
+  ETH_TxDescListTypeDef      TxDescList;                /*!< Tx descriptor wrapper: holds all Tx descriptors list
+                                                            addresses and current descriptor index  */
+
+  ETH_RxDescListTypeDef      RxDescList;                /*!< Rx descriptor wrapper: holds all Rx descriptors list
+                                                            addresses and current descriptor index  */
+
+#ifdef HAL_ETH_USE_PTP
+  ETH_TimeStampTypeDef       TxTimestamp;               /*!< Tx Timestamp */
+#endif /* HAL_ETH_USE_PTP */
+
+  __IO HAL_ETH_StateTypeDef  gState;                   /*!< ETH state information related to global Handle management
+                                                              and also related to Tx operations. This parameter can
+                                                              be a value of @ref HAL_ETH_StateTypeDef */
+
+  __IO uint32_t              ErrorCode;                 /*!< Holds the global Error code of the ETH HAL status machine
+                                                             This parameter can be a value of @ref ETH_Error_Code.*/
+
+  __IO uint32_t
+  DMAErrorCode;              /*!< Holds the DMA Rx Tx Error code when a DMA AIS interrupt occurs
+                                                             This parameter can be a combination of
+                                                             @ref ETH_DMA_Status_Flags */
+
+  __IO uint32_t
+  MACErrorCode;              /*!< Holds the MAC Rx Tx Error code when a MAC Rx or Tx status interrupt occurs
+                                                             This parameter can be a combination of
+                                                             @ref ETH_MAC_Rx_Tx_Status */
+
+  __IO uint32_t              MACWakeUpEvent;            /*!< Holds the Wake Up event when the MAC exit the power down mode
+                                                             This parameter can be a value of
+                                                             @ref ETH_MAC_Wake_Up_Event */
+
+  __IO uint32_t              MACLPIEvent;               /*!< Holds the LPI event when the an LPI status interrupt occurs.
+                                                             This parameter can be a value of @ref ETHEx_LPI_Event */
+
+  __IO uint32_t              IsPtpConfigured;           /*!< Holds the PTP configuration status.
+                                                             This parameter can be a value of
+                                                             @ref ETH_PTP_Config_Status */
+
+#if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
+
+  void (* TxCpltCallback)(struct __ETH_HandleTypeDef *heth);             /*!< ETH Tx Complete Callback */
+  void (* RxCpltCallback)(struct __ETH_HandleTypeDef *heth);            /*!< ETH Rx  Complete Callback     */
+  void (* ErrorCallback)(struct __ETH_HandleTypeDef *heth);             /*!< ETH Error Callback   */
+  void (* PMTCallback)(struct __ETH_HandleTypeDef *heth);               /*!< ETH Power Management Callback            */
+  void (* WakeUpCallback)(struct __ETH_HandleTypeDef *heth);            /*!< ETH Wake UP Callback   */
+
+  void (* MspInitCallback)(struct __ETH_HandleTypeDef *heth);             /*!< ETH Msp Init callback              */
+  void (* MspDeInitCallback)(struct __ETH_HandleTypeDef *heth);           /*!< ETH Msp DeInit callback            */
 
 #endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */
 
-} ETH_HandleTypeDef;
+  pETH_rxAllocateCallbackTypeDef  rxAllocateCallback;  /*!< ETH Rx Get Buffer Function   */
+  pETH_rxLinkCallbackTypeDef      rxLinkCallback; /*!< ETH Rx Set App Data Function */
+  pETH_txFreeCallbackTypeDef      txFreeCallback;       /*!< ETH Tx Free Function         */
+  pETH_txPtpCallbackTypeDef       txPtpCallback;  /*!< ETH Tx Handle Ptp Function */
 
+} ETH_HandleTypeDef;
+/**
+  *
+  */
 
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
 /**
@@ -652,22 +596,76 @@ typedef struct
   */
 typedef enum
 {
-  HAL_ETH_MSPINIT_CB_ID            = 0x00U,    /*!< ETH MspInit callback ID            */
-  HAL_ETH_MSPDEINIT_CB_ID          = 0x01U,    /*!< ETH MspDeInit callback ID          */
-  HAL_ETH_TX_COMPLETE_CB_ID        = 0x02U,    /*!< ETH Tx Complete Callback ID        */
-  HAL_ETH_RX_COMPLETE_CB_ID        = 0x03U,    /*!< ETH Rx Complete Callback ID        */
-  HAL_ETH_DMA_ERROR_CB_ID          = 0x04U,    /*!< ETH DMA Error Callback ID          */
+  HAL_ETH_MSPINIT_CB_ID            = 0x00U,    /*!< ETH MspInit callback ID           */
+  HAL_ETH_MSPDEINIT_CB_ID          = 0x01U,    /*!< ETH MspDeInit callback ID         */
 
-}HAL_ETH_CallbackIDTypeDef;
+  HAL_ETH_TX_COMPLETE_CB_ID        = 0x02U,    /*!< ETH Tx Complete Callback ID       */
+  HAL_ETH_RX_COMPLETE_CB_ID        = 0x03U,    /*!< ETH Rx Complete Callback ID       */
+  HAL_ETH_ERROR_CB_ID              = 0x04U,    /*!< ETH Error Callback ID             */
+  HAL_ETH_PMT_CB_ID                = 0x06U,    /*!< ETH Power Management Callback ID  */
+  HAL_ETH_WAKEUP_CB_ID             = 0x08U     /*!< ETH Wake UP Callback ID           */
+
+
+} HAL_ETH_CallbackIDTypeDef;
 
 /**
   * @brief  HAL ETH Callback pointer definition
   */
-typedef  void (*pETH_CallbackTypeDef)(ETH_HandleTypeDef * heth); /*!< pointer to an ETH callback function */
+typedef  void (*pETH_CallbackTypeDef)(ETH_HandleTypeDef *heth);  /*!< pointer to an ETH callback function */
 
 #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
 
- /**
+/**
+  * @brief  ETH MAC filter structure definition
+  */
+typedef struct
+{
+  FunctionalState PromiscuousMode;          /*!< Enable or Disable Promiscuous Mode */
+
+  FunctionalState ReceiveAllMode;           /*!< Enable or Disable Receive All Mode */
+
+  FunctionalState HachOrPerfectFilter;      /*!< Enable or Disable Perfect filtering in addition to Hash filtering */
+
+  FunctionalState HashUnicast;              /*!< Enable or Disable Hash filtering on unicast packets */
+
+  FunctionalState HashMulticast;            /*!< Enable or Disable Hash filtering on multicast packets */
+
+  FunctionalState PassAllMulticast;         /*!< Enable or Disable passing all multicast packets */
+
+  FunctionalState SrcAddrFiltering;         /*!< Enable or Disable source address filtering module */
+
+  FunctionalState SrcAddrInverseFiltering;  /*!< Enable or Disable source address inverse filtering */
+
+  FunctionalState DestAddrInverseFiltering; /*!< Enable or Disable destination address inverse filtering */
+
+  FunctionalState BroadcastFilter;          /*!< Enable or Disable broadcast filter */
+
+  uint32_t        ControlPacketsFilter;     /*!< Set the control packets filter
+                                                 This parameter can be a value of @ref ETH_Control_Packets_Filter */
+} ETH_MACFilterConfigTypeDef;
+/**
+  *
+  */
+
+/**
+  * @brief  ETH Power Down structure definition
+  */
+typedef struct
+{
+  FunctionalState WakeUpPacket;    /*!< Enable or Disable Wake up packet detection in power down mode */
+
+  FunctionalState MagicPacket;     /*!< Enable or Disable Magic packet detection in power down mode */
+
+  FunctionalState GlobalUnicast;    /*!< Enable or Disable Global unicast packet detection in power down mode */
+
+  FunctionalState WakeUpForward;    /*!< Enable or Disable Forwarding Wake up packets */
+
+} ETH_PowerDownConfigTypeDef;
+/**
+  *
+  */
+
+/**
   * @}
   */
 
@@ -676,81 +674,12 @@ typedef  void (*pETH_CallbackTypeDef)(ETH_HandleTypeDef * heth); /*!< pointer to
   * @{
   */
 
-/** @defgroup ETH_Buffers_setting ETH Buffers setting
-  * @{
-  */ 
-#define ETH_MAX_PACKET_SIZE    ((uint32_t)1524U)    /*!< ETH_HEADER + ETH_EXTRA + ETH_VLAN_TAG + ETH_MAX_ETH_PAYLOAD + ETH_CRC */
-#define ETH_HEADER               ((uint32_t)14U)    /*!< 6 byte Dest addr, 6 byte Src addr, 2 byte length/type */
-#define ETH_CRC                   ((uint32_t)4U)    /*!< Ethernet CRC */
-#define ETH_EXTRA                 ((uint32_t)2U)    /*!< Extra bytes in some cases */   
-#define ETH_VLAN_TAG              ((uint32_t)4U)    /*!< optional 802.1q VLAN Tag */
-#define ETH_MIN_ETH_PAYLOAD       ((uint32_t)46U)    /*!< Minimum Ethernet payload size */
-#define ETH_MAX_ETH_PAYLOAD       ((uint32_t)1500U)    /*!< Maximum Ethernet payload size */
-#define ETH_JUMBO_FRAME_PAYLOAD   ((uint32_t)9000U)    /*!< Jumbo frame payload size */      
-
- /* Ethernet driver receive buffers are organized in a chained linked-list, when
-    an Ethernet packet is received, the Rx-DMA will transfer the packet from RxFIFO
-    to the driver receive buffers memory.
-
-    Depending on the size of the received Ethernet packet and the size of 
-    each Ethernet driver receive buffer, the received packet can take one or more
-    Ethernet driver receive buffer. 
-
-    In below are defined the size of one Ethernet driver receive buffer ETH_RX_BUF_SIZE 
-    and the total count of the driver receive buffers ETH_RXBUFNB.
-
-    The configured value for ETH_RX_BUF_SIZE and ETH_RXBUFNB are only provided as 
-    example, they can be reconfigured in the application layer to fit the application 
-    needs */ 
-
-/* Here we configure each Ethernet driver receive buffer to fit the Max size Ethernet
-   packet */
-#ifndef ETH_RX_BUF_SIZE
- #define ETH_RX_BUF_SIZE         ETH_MAX_PACKET_SIZE 
-#endif
-
-/* 5 Ethernet driver receive buffers are used (in a chained linked list)*/ 
-#ifndef ETH_RXBUFNB
- #define ETH_RXBUFNB             ((uint32_t)5U)     /*  5 Rx buffers of size ETH_RX_BUF_SIZE */
-#endif
-
-
- /* Ethernet driver transmit buffers are organized in a chained linked-list, when
-    an Ethernet packet is transmitted, Tx-DMA will transfer the packet from the 
-    driver transmit buffers memory to the TxFIFO.
-
-    Depending on the size of the Ethernet packet to be transmitted and the size of 
-    each Ethernet driver transmit buffer, the packet to be transmitted can take 
-    one or more Ethernet driver transmit buffer. 
-
-    In below are defined the size of one Ethernet driver transmit buffer ETH_TX_BUF_SIZE 
-    and the total count of the driver transmit buffers ETH_TXBUFNB.
-
-    The configured value for ETH_TX_BUF_SIZE and ETH_TXBUFNB are only provided as 
-    example, they can be reconfigured in the application layer to fit the application 
-    needs */ 
-
-/* Here we configure each Ethernet driver transmit buffer to fit the Max size Ethernet
-   packet */
-#ifndef ETH_TX_BUF_SIZE 
- #define ETH_TX_BUF_SIZE         ETH_MAX_PACKET_SIZE
-#endif
-
-/* 5 Ethernet driver transmit buffers are used (in a chained linked list)*/ 
-#ifndef ETH_TXBUFNB
- #define ETH_TXBUFNB             ((uint32_t)5U)      /* 5  Tx buffers of size ETH_TX_BUF_SIZE */
-#endif
-
- /**
-  * @}
-  */
-
-/** @defgroup ETH_DMA_TX_Descriptor ETH DMA TX Descriptor
+/** @defgroup ETH_DMA_Tx_Descriptor_Bit_Definition ETH DMA Tx Descriptor Bit Definition
   * @{
   */
 
 /*
-   DMA Tx Descriptor
+   DMA Tx Normal Descriptor Read Format
   -----------------------------------------------------------------------------------------------
   TDES0 | OWN(31) | CTRL[30:26] | Reserved[25:24] | CTRL[23:20] | Reserved[19:17] | Status[16:0] |
   -----------------------------------------------------------------------------------------------
@@ -762,9 +691,9 @@ typedef  void (*pETH_CallbackTypeDef)(ETH_HandleTypeDef * heth); /*!< pointer to
   -----------------------------------------------------------------------------------------------
 */
 
-/** 
+/**
   * @brief  Bit definition of TDES0 register: DMA Tx descriptor status register
-  */ 
+  */
 #define ETH_DMATXDESC_OWN                     ((uint32_t)0x80000000U)  /*!< OWN bit: descriptor is owned by DMA engine */
 #define ETH_DMATXDESC_IC                      ((uint32_t)0x40000000U)  /*!< Interrupt on Completion */
 #define ETH_DMATXDESC_LS                      ((uint32_t)0x20000000U)  /*!< Last Segment */
@@ -773,10 +702,10 @@ typedef  void (*pETH_CallbackTypeDef)(ETH_HandleTypeDef * heth); /*!< pointer to
 #define ETH_DMATXDESC_DP                      ((uint32_t)0x04000000U)  /*!< Disable Padding */
 #define ETH_DMATXDESC_TTSE                    ((uint32_t)0x02000000U)  /*!< Transmit Time Stamp Enable */
 #define ETH_DMATXDESC_CIC                     ((uint32_t)0x00C00000U)  /*!< Checksum Insertion Control: 4 cases */
-#define ETH_DMATXDESC_CIC_BYPASS              ((uint32_t)0x00000000U)  /*!< Do Nothing: Checksum Engine is bypassed */ 
-#define ETH_DMATXDESC_CIC_IPV4HEADER          ((uint32_t)0x00400000U)  /*!< IPV4 header Checksum Insertion */ 
-#define ETH_DMATXDESC_CIC_TCPUDPICMP_SEGMENT  ((uint32_t)0x00800000U)  /*!< TCP/UDP/ICMP Checksum Insertion calculated over segment only */ 
-#define ETH_DMATXDESC_CIC_TCPUDPICMP_FULL     ((uint32_t)0x00C00000U)  /*!< TCP/UDP/ICMP Checksum Insertion fully calculated */ 
+#define ETH_DMATXDESC_CIC_BYPASS              ((uint32_t)0x00000000U)  /*!< Do Nothing: Checksum Engine is bypassed */
+#define ETH_DMATXDESC_CIC_IPV4HEADER          ((uint32_t)0x00400000U)  /*!< IPV4 header Checksum Insertion */
+#define ETH_DMATXDESC_CIC_TCPUDPICMP_SEGMENT  ((uint32_t)0x00800000U)  /*!< TCP/UDP/ICMP Checksum Insertion calculated over segment only */
+#define ETH_DMATXDESC_CIC_TCPUDPICMP_FULL     ((uint32_t)0x00C00000U)  /*!< TCP/UDP/ICMP Checksum Insertion fully calculated */
 #define ETH_DMATXDESC_TER                     ((uint32_t)0x00200000U)  /*!< Transmit End of Ring */
 #define ETH_DMATXDESC_TCH                     ((uint32_t)0x00100000U)  /*!< Second Address Chained */
 #define ETH_DMATXDESC_TTSS                    ((uint32_t)0x00020000U)  /*!< Tx Time Stamp Status */
@@ -795,43 +724,45 @@ typedef  void (*pETH_CallbackTypeDef)(ETH_HandleTypeDef * heth); /*!< pointer to
 #define ETH_DMATXDESC_UF                      ((uint32_t)0x00000002U)  /*!< Underflow Error: late data arrival from the memory */
 #define ETH_DMATXDESC_DB                      ((uint32_t)0x00000001U)  /*!< Deferred Bit */
 
-/** 
+/**
   * @brief  Bit definition of TDES1 register
-  */ 
+  */
 #define ETH_DMATXDESC_TBS2  ((uint32_t)0x1FFF0000U)  /*!< Transmit Buffer2 Size */
 #define ETH_DMATXDESC_TBS1  ((uint32_t)0x00001FFFU)  /*!< Transmit Buffer1 Size */
 
-/** 
+/**
   * @brief  Bit definition of TDES2 register
-  */ 
+  */
 #define ETH_DMATXDESC_B1AP  ((uint32_t)0xFFFFFFFFU)  /*!< Buffer1 Address Pointer */
 
-/** 
+/**
   * @brief  Bit definition of TDES3 register
-  */ 
+  */
 #define ETH_DMATXDESC_B2AP  ((uint32_t)0xFFFFFFFFU)  /*!< Buffer2 Address Pointer */
 
-  /*---------------------------------------------------------------------------------------------
-  TDES6 |                         Transmit Time Stamp Low [31:0]                                 |
-  -----------------------------------------------------------------------------------------------
-  TDES7 |                         Transmit Time Stamp High [31:0]                                |
-  ----------------------------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------------------------
+TDES6 |                         Transmit Time Stamp Low [31:0]                                 |
+-----------------------------------------------------------------------------------------------
+TDES7 |                         Transmit Time Stamp High [31:0]                                |
+----------------------------------------------------------------------------------------------*/
 
 /* Bit definition of TDES6 register */
- #define ETH_DMAPTPTXDESC_TTSL  ((uint32_t)0xFFFFFFFFU)  /* Transmit Time Stamp Low */
+#define ETH_DMAPTPTXDESC_TTSL  ((uint32_t)0xFFFFFFFFU)  /* Transmit Time Stamp Low */
 
 /* Bit definition of TDES7 register */
- #define ETH_DMAPTPTXDESC_TTSH  ((uint32_t)0xFFFFFFFFU)  /* Transmit Time Stamp High */
+#define ETH_DMAPTPTXDESC_TTSH  ((uint32_t)0xFFFFFFFFU)  /* Transmit Time Stamp High */
 
 /**
   * @}
-  */ 
-/** @defgroup ETH_DMA_RX_Descriptor ETH DMA RX Descriptor
+  */
+
+
+/** @defgroup ETH_DMA_Rx_Descriptor_Bit_Definition ETH DMA Rx Descriptor Bit Definition
   * @{
   */
 
 /*
-  DMA Rx Descriptor
+  DMA Rx Normal Descriptor read format
   --------------------------------------------------------------------------------------------------------------------
   RDES0 | OWN(31) |                                             Status [30:0]                                          |
   ---------------------------------------------------------------------------------------------------------------------
@@ -843,9 +774,9 @@ typedef  void (*pETH_CallbackTypeDef)(ETH_HandleTypeDef * heth); /*!< pointer to
   ---------------------------------------------------------------------------------------------------------------------
 */
 
-/** 
+/**
   * @brief  Bit definition of RDES0 register: DMA Rx descriptor status register
-  */ 
+  */
 #define ETH_DMARXDESC_OWN         ((uint32_t)0x80000000U)  /*!< OWN bit: descriptor is owned by DMA engine  */
 #define ETH_DMARXDESC_AFM         ((uint32_t)0x40000000U)  /*!< DA Filter Fail for the rx frame  */
 #define ETH_DMARXDESC_FL          ((uint32_t)0x3FFF0000U)  /*!< Receive descriptor frame length  */
@@ -856,8 +787,8 @@ typedef  void (*pETH_CallbackTypeDef)(ETH_HandleTypeDef * heth); /*!< pointer to
 #define ETH_DMARXDESC_OE          ((uint32_t)0x00000800U)  /*!< Overflow Error: Frame was damaged due to buffer overflow */
 #define ETH_DMARXDESC_VLAN        ((uint32_t)0x00000400U)  /*!< VLAN Tag: received frame is a VLAN frame */
 #define ETH_DMARXDESC_FS          ((uint32_t)0x00000200U)  /*!< First descriptor of the frame  */
-#define ETH_DMARXDESC_LS          ((uint32_t)0x00000100U)  /*!< Last descriptor of the frame  */ 
-#define ETH_DMARXDESC_IPV4HCE     ((uint32_t)0x00000080U)  /*!< IPC Checksum Error: Rx Ipv4 header checksum error   */    
+#define ETH_DMARXDESC_LS          ((uint32_t)0x00000100U)  /*!< Last descriptor of the frame  */
+#define ETH_DMARXDESC_IPV4HCE     ((uint32_t)0x00000080U)  /*!< IPC Checksum Error: Rx Ipv4 header checksum error   */
 #define ETH_DMARXDESC_LC          ((uint32_t)0x00000040U)  /*!< Late collision occurred during reception   */
 #define ETH_DMARXDESC_FT          ((uint32_t)0x00000020U)  /*!< Frame type - Ethernet, otherwise 802.3    */
 #define ETH_DMARXDESC_RWT         ((uint32_t)0x00000010U)  /*!< Receive Watchdog Timeout: watchdog timer expired during reception    */
@@ -866,23 +797,23 @@ typedef  void (*pETH_CallbackTypeDef)(ETH_HandleTypeDef * heth); /*!< pointer to
 #define ETH_DMARXDESC_CE          ((uint32_t)0x00000002U)  /*!< CRC error */
 #define ETH_DMARXDESC_MAMPCE      ((uint32_t)0x00000001U)  /*!< Rx MAC Address/Payload Checksum Error: Rx MAC address matched/ Rx Payload Checksum Error */
 
-/** 
+/**
   * @brief  Bit definition of RDES1 register
-  */ 
+  */
 #define ETH_DMARXDESC_DIC   ((uint32_t)0x80000000U)  /*!< Disable Interrupt on Completion */
 #define ETH_DMARXDESC_RBS2  ((uint32_t)0x1FFF0000U)  /*!< Receive Buffer2 Size */
 #define ETH_DMARXDESC_RER   ((uint32_t)0x00008000U)  /*!< Receive End of Ring */
 #define ETH_DMARXDESC_RCH   ((uint32_t)0x00004000U)  /*!< Second Address Chained */
 #define ETH_DMARXDESC_RBS1  ((uint32_t)0x00001FFFU)  /*!< Receive Buffer1 Size */
 
-/** 
-  * @brief  Bit definition of RDES2 register  
-  */ 
+/**
+  * @brief  Bit definition of RDES2 register
+  */
 #define ETH_DMARXDESC_B1AP  ((uint32_t)0xFFFFFFFFU)  /*!< Buffer1 Address Pointer */
 
-/** 
-  * @brief  Bit definition of RDES3 register  
-  */ 
+/**
+  * @brief  Bit definition of RDES3 register
+  */
 #define ETH_DMARXDESC_B2AP  ((uint32_t)0xFFFFFFFFU)  /*!< Buffer2 Address Pointer */
 
 /*---------------------------------------------------------------------------------------------------------------------
@@ -899,327 +830,438 @@ typedef  void (*pETH_CallbackTypeDef)(ETH_HandleTypeDef * heth); /*!< pointer to
 #define ETH_DMAPTPRXDESC_PTPV                            ((uint32_t)0x00002000U)  /* PTP Version */
 #define ETH_DMAPTPRXDESC_PTPFT                           ((uint32_t)0x00001000U)  /* PTP Frame Type */
 #define ETH_DMAPTPRXDESC_PTPMT                           ((uint32_t)0x00000F00U)  /* PTP Message Type */
-#define ETH_DMAPTPRXDESC_PTPMT_SYNC                      ((uint32_t)0x00000100U)  /* SYNC message (all clock types) */
-#define ETH_DMAPTPRXDESC_PTPMT_FOLLOWUP                  ((uint32_t)0x00000200U)  /* FollowUp message (all clock types) */ 
-#define ETH_DMAPTPRXDESC_PTPMT_DELAYREQ                  ((uint32_t)0x00000300U)  /* DelayReq message (all clock types) */ 
-#define ETH_DMAPTPRXDESC_PTPMT_DELAYRESP                 ((uint32_t)0x00000400U)  /* DelayResp message (all clock types) */ 
-#define ETH_DMAPTPRXDESC_PTPMT_PDELAYREQ_ANNOUNCE        ((uint32_t)0x00000500U)  /* PdelayReq message (peer-to-peer transparent clock) or Announce message (Ordinary or Boundary clock) */ 
-#define ETH_DMAPTPRXDESC_PTPMT_PDELAYRESP_MANAG          ((uint32_t)0x00000600U)  /* PdelayResp message (peer-to-peer transparent clock) or Management message (Ordinary or Boundary clock)  */ 
-#define ETH_DMAPTPRXDESC_PTPMT_PDELAYRESPFOLLOWUP_SIGNAL ((uint32_t)0x00000700U)  /* PdelayRespFollowUp message (peer-to-peer transparent clock) or Signaling message (Ordinary or Boundary clock) */           
+#define ETH_DMAPTPRXDESC_PTPMT_SYNC                      ((uint32_t)0x00000100U)  /* SYNC message
+                                                                                     (all clock types) */
+#define ETH_DMAPTPRXDESC_PTPMT_FOLLOWUP                  ((uint32_t)0x00000200U)  /* FollowUp message
+                                                                                     (all clock types) */
+#define ETH_DMAPTPRXDESC_PTPMT_DELAYREQ                  ((uint32_t)0x00000300U)  /* DelayReq message
+                                                                                     (all clock types) */
+#define ETH_DMAPTPRXDESC_PTPMT_DELAYRESP                 ((uint32_t)0x00000400U)  /* DelayResp message
+                                                                                     (all clock types) */
+#define ETH_DMAPTPRXDESC_PTPMT_PDELAYREQ_ANNOUNCE        ((uint32_t)0x00000500U)  /* PdelayReq message
+                                                                                     (peer-to-peer transparent clock)
+                                                                                      or Announce message (Ordinary
+                                                                                      or Boundary clock) */
+#define ETH_DMAPTPRXDESC_PTPMT_PDELAYRESP_MANAG          ((uint32_t)0x00000600U)  /* PdelayResp message
+                                                                                     (peer-to-peer transparent clock)
+                                                                                      or Management message (Ordinary
+                                                                                      or Boundary clock)  */
+#define ETH_DMAPTPRXDESC_PTPMT_PDELAYRESPFOLLOWUP_SIGNAL ((uint32_t)0x00000700U)  /* PdelayRespFollowUp message
+                                                                                    (peer-to-peer transparent clock)
+                                                                                     or Signaling message (Ordinary
+                                                                                     or Boundary clock) */
 #define ETH_DMAPTPRXDESC_IPV6PR                          ((uint32_t)0x00000080U)  /* IPv6 Packet Received */
 #define ETH_DMAPTPRXDESC_IPV4PR                          ((uint32_t)0x00000040U)  /* IPv4 Packet Received */
 #define ETH_DMAPTPRXDESC_IPCB                            ((uint32_t)0x00000020U)  /* IP Checksum Bypassed */
 #define ETH_DMAPTPRXDESC_IPPE                            ((uint32_t)0x00000010U)  /* IP Payload Error */
 #define ETH_DMAPTPRXDESC_IPHE                            ((uint32_t)0x00000008U)  /* IP Header Error */
 #define ETH_DMAPTPRXDESC_IPPT                            ((uint32_t)0x00000007U)  /* IP Payload Type */
-#define ETH_DMAPTPRXDESC_IPPT_UDP                        ((uint32_t)0x00000001U)  /* UDP payload encapsulated in the IP datagram */
-#define ETH_DMAPTPRXDESC_IPPT_TCP                        ((uint32_t)0x00000002U)  /* TCP payload encapsulated in the IP datagram */ 
-#define ETH_DMAPTPRXDESC_IPPT_ICMP                       ((uint32_t)0x00000003U)  /* ICMP payload encapsulated in the IP datagram */
+#define ETH_DMAPTPRXDESC_IPPT_UDP                        ((uint32_t)0x00000001U)  /* UDP payload encapsulated in
+                                                                                     the IP datagram */
+#define ETH_DMAPTPRXDESC_IPPT_TCP                        ((uint32_t)0x00000002U)  /* TCP payload encapsulated in
+                                                                                     the IP datagram */
+#define ETH_DMAPTPRXDESC_IPPT_ICMP                       ((uint32_t)0x00000003U)  /* ICMP payload encapsulated in
+                                                                                     the IP datagram */
 
 /* Bit definition of RDES6 register */
 #define ETH_DMAPTPRXDESC_RTSL  ((uint32_t)0xFFFFFFFFU)  /* Receive Time Stamp Low */
 
 /* Bit definition of RDES7 register */
 #define ETH_DMAPTPRXDESC_RTSH  ((uint32_t)0xFFFFFFFFU)  /* Receive Time Stamp High */
-/**
-  * @}
-  */
- /** @defgroup ETH_AutoNegotiation ETH AutoNegotiation 
-  * @{
-  */ 
-#define ETH_AUTONEGOTIATION_ENABLE     ((uint32_t)0x00000001U)
-#define ETH_AUTONEGOTIATION_DISABLE    ((uint32_t)0x00000000U)
 
 /**
   * @}
   */
-/** @defgroup ETH_Speed ETH Speed 
+
+/** @defgroup ETH_Frame_settings ETH frame settings
   * @{
-  */ 
+  */
+#define ETH_MAX_PACKET_SIZE      ((uint32_t)1528U)    /*!< ETH_HEADER + 2*VLAN_TAG + MAX_ETH_PAYLOAD + ETH_CRC */
+#define ETH_HEADER               ((uint32_t)14U)    /*!< 6 byte Dest addr, 6 byte Src addr, 2 byte length/type */
+#define ETH_CRC                  ((uint32_t)4U)    /*!< Ethernet CRC */
+#define ETH_VLAN_TAG             ((uint32_t)4U)    /*!< optional 802.1q VLAN Tag */
+#define ETH_MIN_PAYLOAD          ((uint32_t)46U)    /*!< Minimum Ethernet payload size */
+#define ETH_MAX_PAYLOAD          ((uint32_t)1500U)    /*!< Maximum Ethernet payload size */
+#define ETH_JUMBO_FRAME_PAYLOAD  ((uint32_t)9000U)    /*!< Jumbo frame payload size */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Error_Code ETH Error Code
+  * @{
+  */
+#define HAL_ETH_ERROR_NONE         ((uint32_t)0x00000000U)   /*!< No error            */
+#define HAL_ETH_ERROR_PARAM        ((uint32_t)0x00000001U)   /*!< Busy error          */
+#define HAL_ETH_ERROR_BUSY         ((uint32_t)0x00000002U)   /*!< Parameter error     */
+#define HAL_ETH_ERROR_TIMEOUT      ((uint32_t)0x00000004U)   /*!< Timeout error       */
+#define HAL_ETH_ERROR_DMA          ((uint32_t)0x00000008U)   /*!< DMA transfer error  */
+#define HAL_ETH_ERROR_MAC          ((uint32_t)0x00000010U)   /*!< MAC transfer error  */
+#if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
+#define HAL_ETH_ERROR_INVALID_CALLBACK ((uint32_t)0x00000020U)    /*!< Invalid Callback error  */
+#endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Tx_Packet_Attributes ETH Tx Packet Attributes
+  * @{
+  */
+#define ETH_TX_PACKETS_FEATURES_CSUM          ((uint32_t)0x00000001U)
+#define ETH_TX_PACKETS_FEATURES_SAIC          ((uint32_t)0x00000002U)
+#define ETH_TX_PACKETS_FEATURES_VLANTAG       ((uint32_t)0x00000004U)
+#define ETH_TX_PACKETS_FEATURES_INNERVLANTAG  ((uint32_t)0x00000008U)
+#define ETH_TX_PACKETS_FEATURES_TSO           ((uint32_t)0x00000010U)
+#define ETH_TX_PACKETS_FEATURES_CRCPAD        ((uint32_t)0x00000020U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Tx_Packet_Source_Addr_Control ETH Tx Packet Source Addr Control
+  * @{
+  */
+#define ETH_SRC_ADDR_CONTROL_DISABLE          ETH_DMATXNDESCRF_SAIC_DISABLE
+#define ETH_SRC_ADDR_INSERT                   ETH_DMATXNDESCRF_SAIC_INSERT
+#define ETH_SRC_ADDR_REPLACE                  ETH_DMATXNDESCRF_SAIC_REPLACE
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Tx_Packet_CRC_Pad_Control ETH Tx Packet CRC Pad Control
+  * @{
+  */
+#define ETH_CRC_PAD_DISABLE      (uint32_t)(ETH_DMATXDESC_DP | ETH_DMATXDESC_DC)
+#define ETH_CRC_PAD_INSERT       ((uint32_t)0x00000000U)
+#define ETH_CRC_INSERT           ETH_DMATXDESC_DP
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Tx_Packet_Checksum_Control ETH Tx Packet Checksum Control
+  * @{
+  */
+#define ETH_CHECKSUM_DISABLE                         ETH_DMATXDESC_CIC_BYPASS
+#define ETH_CHECKSUM_IPHDR_INSERT                    ETH_DMATXDESC_CIC_IPV4HEADER
+#define ETH_CHECKSUM_IPHDR_PAYLOAD_INSERT            ETH_DMATXDESC_CIC_TCPUDPICMP_SEGMENT
+#define ETH_CHECKSUM_IPHDR_PAYLOAD_INSERT_PHDR_CALC  ETH_DMATXDESC_CIC_TCPUDPICMP_FULL
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Tx_Packet_VLAN_Control ETH Tx Packet VLAN Control
+  * @{
+  */
+#define ETH_VLAN_DISABLE  ETH_DMATXNDESCRF_VTIR_DISABLE
+#define ETH_VLAN_REMOVE   ETH_DMATXNDESCRF_VTIR_REMOVE
+#define ETH_VLAN_INSERT   ETH_DMATXNDESCRF_VTIR_INSERT
+#define ETH_VLAN_REPLACE  ETH_DMATXNDESCRF_VTIR_REPLACE
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Tx_Packet_Inner_VLAN_Control ETH Tx Packet Inner VLAN Control
+  * @{
+  */
+#define ETH_INNER_VLAN_DISABLE  ETH_DMATXCDESC_IVTIR_DISABLE
+#define ETH_INNER_VLAN_REMOVE   ETH_DMATXCDESC_IVTIR_REMOVE
+#define ETH_INNER_VLAN_INSERT   ETH_DMATXCDESC_IVTIR_INSERT
+#define ETH_INNER_VLAN_REPLACE  ETH_DMATXCDESC_IVTIR_REPLACE
+/**
+  * @}
+  */
+
+
+/** @defgroup ETH_Rx_MAC_Filter_Status ETH Rx MAC Filter Status
+  * @{
+  */
+#define ETH_VLAN_FILTER_PASS        ETH_DMARXDESC_VLAN
+#define ETH_DEST_ADDRESS_FAIL       ETH_DMARXDESC_AFM
+#define ETH_SOURCE_ADDRESS_FAIL     ETH_DMARXDESC_SAF
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Rx_Error_Code ETH Rx Error Code
+  * @{
+  */
+#define ETH_DRIBBLE_BIT_ERROR   ETH_DMARXDESC_DBE
+#define ETH_RECEIVE_ERROR       ETH_DMARXDESC_RE
+#define ETH_RECEIVE_OVERFLOW    ETH_DMARXDESC_OE
+#define ETH_WATCHDOG_TIMEOUT    ETH_DMARXDESC_RWT
+#define ETH_GIANT_PACKET        ETH_DMARXDESC_IPV4HC
+#define ETH_CRC_ERROR           ETH_DMARXDESC_CE
+/**
+  * @}
+  */
+
+/** @defgroup ETH_DMA_Arbitration ETH DMA Arbitration
+  * @{
+  */
+#define ETH_DMAARBITRATION_RX        ETH_DMAMR_DA
+#define ETH_DMAARBITRATION_RX1_TX1   ((uint32_t)0x00000000U)
+#define ETH_DMAARBITRATION_RX2_TX1   ETH_DMAMR_PR_2_1
+#define ETH_DMAARBITRATION_RX3_TX1   ETH_DMAMR_PR_3_1
+#define ETH_DMAARBITRATION_RX4_TX1   ETH_DMAMR_PR_4_1
+#define ETH_DMAARBITRATION_RX5_TX1   ETH_DMAMR_PR_5_1
+#define ETH_DMAARBITRATION_RX6_TX1   ETH_DMAMR_PR_6_1
+#define ETH_DMAARBITRATION_RX7_TX1   ETH_DMAMR_PR_7_1
+#define ETH_DMAARBITRATION_RX8_TX1   ETH_DMAMR_PR_8_1
+#define ETH_DMAARBITRATION_TX        (ETH_DMAMR_TXPR | ETH_DMAMR_DA)
+#define ETH_DMAARBITRATION_TX1_RX1   ((uint32_t)0x00000000U)
+#define ETH_DMAARBITRATION_TX2_RX1   (ETH_DMAMR_TXPR | ETH_DMAMR_PR_2_1)
+#define ETH_DMAARBITRATION_TX3_RX1   (ETH_DMAMR_TXPR | ETH_DMAMR_PR_3_1)
+#define ETH_DMAARBITRATION_TX4_RX1   (ETH_DMAMR_TXPR | ETH_DMAMR_PR_4_1)
+#define ETH_DMAARBITRATION_TX5_RX1   (ETH_DMAMR_TXPR | ETH_DMAMR_PR_5_1)
+#define ETH_DMAARBITRATION_TX6_RX1   (ETH_DMAMR_TXPR | ETH_DMAMR_PR_6_1)
+#define ETH_DMAARBITRATION_TX7_RX1   (ETH_DMAMR_TXPR | ETH_DMAMR_PR_7_1)
+#define ETH_DMAARBITRATION_TX8_RX1   (ETH_DMAMR_TXPR | ETH_DMAMR_PR_8_1)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Burst_Mode ETH Burst Mode
+  * @{
+  */
+#define ETH_BURSTLENGTH_FIXED           ETH_DMABMR_FB
+#define ETH_BURSTLENGTH_MIXED           ETH_DMABMR_MB
+#define ETH_BURSTLENGTH_UNSPECIFIED     ((uint32_t)0x00000000U)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Tx_DMA_Burst_Length ETH Tx DMA Burst Length
+  * @{
+  */
+#define ETH_TXDMABURSTLENGTH_1BEAT          0x00000100U  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 1 */
+#define ETH_TXDMABURSTLENGTH_2BEAT          0x00000200U  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 2 */
+#define ETH_TXDMABURSTLENGTH_4BEAT          0x00000400U  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
+#define ETH_TXDMABURSTLENGTH_8BEAT          0x00000800U  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
+#define ETH_TXDMABURSTLENGTH_16BEAT         0x00001000U  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
+#define ETH_TXDMABURSTLENGTH_32BEAT         0x00002000U  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
+#define ETH_TXDMABURSTLENGTH_4XPBL_4BEAT    0x01000100U  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
+#define ETH_TXDMABURSTLENGTH_4XPBL_8BEAT    0x01000200U  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
+#define ETH_TXDMABURSTLENGTH_4XPBL_16BEAT   0x01000400U  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
+#define ETH_TXDMABURSTLENGTH_4XPBL_32BEAT   0x01000800U  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
+#define ETH_TXDMABURSTLENGTH_4XPBL_64BEAT   0x01001000U  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 64 */
+#define ETH_TXDMABURSTLENGTH_4XPBL_128BEAT  0x01002000U  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 128 */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Rx_DMA_Burst_Length ETH Rx DMA Burst Length
+  * @{
+  */
+#define ETH_RXDMABURSTLENGTH_1BEAT          0x00020000U  /*!< maximum number of beats to be transferred in one RxDMA transaction is 1 */
+#define ETH_RXDMABURSTLENGTH_2BEAT          0x00040000U  /*!< maximum number of beats to be transferred in one RxDMA transaction is 2 */
+#define ETH_RXDMABURSTLENGTH_4BEAT          0x00080000U  /*!< maximum number of beats to be transferred in one RxDMA transaction is 4 */
+#define ETH_RXDMABURSTLENGTH_8BEAT          0x00100000U  /*!< maximum number of beats to be transferred in one RxDMA transaction is 8 */
+#define ETH_RXDMABURSTLENGTH_16BEAT         0x00200000U  /*!< maximum number of beats to be transferred in one RxDMA transaction is 16 */
+#define ETH_RXDMABURSTLENGTH_32BEAT         0x00400000U  /*!< maximum number of beats to be transferred in one RxDMA transaction is 32 */
+#define ETH_RXDMABURSTLENGTH_4XPBL_4BEAT    0x01020000U  /*!< maximum number of beats to be transferred in one RxDMA transaction is 4 */
+#define ETH_RXDMABURSTLENGTH_4XPBL_8BEAT    0x01040000U  /*!< maximum number of beats to be transferred in one RxDMA transaction is 8 */
+#define ETH_RXDMABURSTLENGTH_4XPBL_16BEAT   0x01080000U  /*!< maximum number of beats to be transferred in one RxDMA transaction is 16 */
+#define ETH_RXDMABURSTLENGTH_4XPBL_32BEAT   0x01100000U  /*!< maximum number of beats to be transferred in one RxDMA transaction is 32 */
+#define ETH_RXDMABURSTLENGTH_4XPBL_64BEAT   0x01200000U  /*!< maximum number of beats to be transferred in one RxDMA transaction is 64 */
+#define ETH_RXDMABURSTLENGTH_4XPBL_128BEAT  0x01400000U  /*!< maximum number of beats to be transferred in one RxDMA transaction is 128 */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_DMA_Interrupts ETH DMA Interrupts
+  * @{
+  */
+#define ETH_DMA_NORMAL_IT                 ETH_DMACIER_NIE
+#define ETH_DMA_ABNORMAL_IT               ETH_DMACIER_AIE
+#define ETH_DMA_CONTEXT_DESC_ERROR_IT     ETH_DMACIER_CDEE
+#define ETH_DMA_FATAL_BUS_ERROR_IT        ETH_DMACIER_FBEE
+#define ETH_DMA_EARLY_RX_IT               ETH_DMACIER_ERIE
+#define ETH_DMA_EARLY_TX_IT               ETH_DMACIER_ETIE
+#define ETH_DMA_RX_WATCHDOG_TIMEOUT_IT    ETH_DMACIER_RWTE
+#define ETH_DMA_RX_PROCESS_STOPPED_IT     ETH_DMACIER_RSE
+#define ETH_DMA_RX_BUFFER_UNAVAILABLE_IT  ETH_DMACIER_RBUE
+#define ETH_DMA_RX_IT                     ETH_DMACIER_RIE
+#define ETH_DMA_TX_BUFFER_UNAVAILABLE_IT  ETH_DMACIER_TBUE
+#define ETH_DMA_TX_PROCESS_STOPPED_IT     ETH_DMACIER_TXSE
+#define ETH_DMA_TX_IT                     ETH_DMACIER_TIE
+/**
+  * @}
+  */
+
+/** @defgroup ETH_DMA_Status_Flags ETH DMA Status Flags
+  * @{
+  */
+#define ETH_DMA_RX_NO_ERROR_FLAG                 ((uint32_t)0x00000000U)
+#define ETH_DMA_RX_DESC_READ_ERROR_FLAG          (ETH_DMACSR_REB_BIT_2 | ETH_DMACSR_REB_BIT_1 | ETH_DMACSR_REB_BIT_0)
+#define ETH_DMA_RX_DESC_WRITE_ERROR_FLAG         (ETH_DMACSR_REB_BIT_2 | ETH_DMACSR_REB_BIT_1)
+#define ETH_DMA_RX_BUFFER_READ_ERROR_FLAG        (ETH_DMACSR_REB_BIT_2 | ETH_DMACSR_REB_BIT_0)
+#define ETH_DMA_RX_BUFFER_WRITE_ERROR_FLAG        ETH_DMACSR_REB_BIT_2
+#define ETH_DMA_TX_NO_ERROR_FLAG                 ((uint32_t)0x00000000U)
+#define ETH_DMA_TX_DESC_READ_ERROR_FLAG          (ETH_DMACSR_TEB_BIT_2 | ETH_DMACSR_TEB_BIT_1 | ETH_DMACSR_TEB_BIT_0)
+#define ETH_DMA_TX_DESC_WRITE_ERROR_FLAG         (ETH_DMACSR_TEB_BIT_2 | ETH_DMACSR_TEB_BIT_1)
+#define ETH_DMA_TX_BUFFER_READ_ERROR_FLAG        (ETH_DMACSR_TEB_BIT_2 | ETH_DMACSR_TEB_BIT_0)
+#define ETH_DMA_TX_BUFFER_WRITE_ERROR_FLAG        ETH_DMACSR_TEB_BIT_2
+#define ETH_DMA_CONTEXT_DESC_ERROR_FLAG           ETH_DMACSR_CDE
+#define ETH_DMA_FATAL_BUS_ERROR_FLAG              ETH_DMACSR_FBE
+#define ETH_DMA_EARLY_TX_IT_FLAG                  ETH_DMACSR_ERI
+#define ETH_DMA_RX_WATCHDOG_TIMEOUT_FLAG          ETH_DMACSR_RWT
+#define ETH_DMA_RX_PROCESS_STOPPED_FLAG           ETH_DMACSR_RPS
+#define ETH_DMA_RX_BUFFER_UNAVAILABLE_FLAG        ETH_DMACSR_RBU
+#define ETH_DMA_TX_PROCESS_STOPPED_FLAG           ETH_DMACSR_TPS
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Transmit_Mode ETH Transmit Mode
+  * @{
+  */
+#define ETH_TRANSMITSTOREFORWARD       ETH_MTLTQOMR_TSF
+#define ETH_TRANSMITTHRESHOLD_32       ETH_MTLTQOMR_TTC_32BITS
+#define ETH_TRANSMITTHRESHOLD_64       ETH_MTLTQOMR_TTC_64BITS
+#define ETH_TRANSMITTHRESHOLD_96       ETH_MTLTQOMR_TTC_96BITS
+#define ETH_TRANSMITTHRESHOLD_128      ETH_MTLTQOMR_TTC_128BITS
+#define ETH_TRANSMITTHRESHOLD_192      ETH_MTLTQOMR_TTC_192BITS
+#define ETH_TRANSMITTHRESHOLD_256      ETH_MTLTQOMR_TTC_256BITS
+#define ETH_TRANSMITTHRESHOLD_384      ETH_MTLTQOMR_TTC_384BITS
+#define ETH_TRANSMITTHRESHOLD_512      ETH_MTLTQOMR_TTC_512BITS
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Receive_Mode ETH Receive Mode
+  * @{
+  */
+#define ETH_RECEIVESTOREFORWARD        ETH_MTLRQOMR_RSF
+#define ETH_RECEIVETHRESHOLD8_64       ETH_MTLRQOMR_RTC_64BITS
+#define ETH_RECEIVETHRESHOLD8_32       ETH_MTLRQOMR_RTC_32BITS
+#define ETH_RECEIVETHRESHOLD8_96       ETH_MTLRQOMR_RTC_96BITS
+#define ETH_RECEIVETHRESHOLD8_128      ETH_MTLRQOMR_RTC_128BITS
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Pause_Low_Threshold  ETH Pause Low Threshold
+  * @{
+  */
+#define ETH_PAUSELOWTHRESHOLD_MINUS_4        ETH_MACTFCR_PLT_MINUS4
+#define ETH_PAUSELOWTHRESHOLD_MINUS_28       ETH_MACTFCR_PLT_MINUS28
+#define ETH_PAUSELOWTHRESHOLD_MINUS_36       ETH_MACTFCR_PLT_MINUS36
+#define ETH_PAUSELOWTHRESHOLD_MINUS_144      ETH_MACTFCR_PLT_MINUS144
+#define ETH_PAUSELOWTHRESHOLD_MINUS_256      ETH_MACTFCR_PLT_MINUS256
+#define ETH_PAUSELOWTHRESHOLD_MINUS_512      ETH_MACTFCR_PLT_MINUS512
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Watchdog_Timeout ETH Watchdog Timeout
+  * @{
+  */
+#define ETH_WATCHDOGTIMEOUT_2KB      ETH_MACWTR_WTO_2KB
+#define ETH_WATCHDOGTIMEOUT_3KB      ETH_MACWTR_WTO_3KB
+#define ETH_WATCHDOGTIMEOUT_4KB      ETH_MACWTR_WTO_4KB
+#define ETH_WATCHDOGTIMEOUT_5KB      ETH_MACWTR_WTO_5KB
+#define ETH_WATCHDOGTIMEOUT_6KB      ETH_MACWTR_WTO_6KB
+#define ETH_WATCHDOGTIMEOUT_7KB      ETH_MACWTR_WTO_7KB
+#define ETH_WATCHDOGTIMEOUT_8KB      ETH_MACWTR_WTO_8KB
+#define ETH_WATCHDOGTIMEOUT_9KB      ETH_MACWTR_WTO_9KB
+#define ETH_WATCHDOGTIMEOUT_10KB     ETH_MACWTR_WTO_10KB
+#define ETH_WATCHDOGTIMEOUT_11KB     ETH_MACWTR_WTO_12KB
+#define ETH_WATCHDOGTIMEOUT_12KB     ETH_MACWTR_WTO_12KB
+#define ETH_WATCHDOGTIMEOUT_13KB     ETH_MACWTR_WTO_13KB
+#define ETH_WATCHDOGTIMEOUT_14KB     ETH_MACWTR_WTO_14KB
+#define ETH_WATCHDOGTIMEOUT_15KB     ETH_MACWTR_WTO_15KB
+#define ETH_WATCHDOGTIMEOUT_16KB     ETH_MACWTR_WTO_16KB
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Inter_Packet_Gap ETH Inter Packet Gap
+  * @{
+  */
+#define ETH_INTERPACKETGAP_96BIT   ETH_MACCR_IPG_96BIT
+#define ETH_INTERPACKETGAP_88BIT   ETH_MACCR_IPG_88BIT
+#define ETH_INTERPACKETGAP_80BIT   ETH_MACCR_IPG_80BIT
+#define ETH_INTERPACKETGAP_72BIT   ETH_MACCR_IPG_72BIT
+#define ETH_INTERPACKETGAP_64BIT   ETH_MACCR_IPG_64BIT
+#define ETH_INTERPACKETGAP_56BIT   ETH_MACCR_IPG_56BIT
+#define ETH_INTERPACKETGAP_48BIT   ETH_MACCR_IPG_48BIT
+#define ETH_INTERPACKETGAP_40BIT   ETH_MACCR_IPG_40BIT
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Speed  ETH Speed
+  * @{
+  */
 #define ETH_SPEED_10M        ((uint32_t)0x00000000U)
-#define ETH_SPEED_100M       ((uint32_t)0x00004000U)
-
+#define ETH_SPEED_100M       0x00004000U
 /**
   * @}
   */
+
 /** @defgroup ETH_Duplex_Mode ETH Duplex Mode
   * @{
-  */ 
-#define ETH_MODE_FULLDUPLEX       ((uint32_t)0x00000800U)
-#define ETH_MODE_HALFDUPLEX       ((uint32_t)0x00000000U)
-/**
-  * @}
   */
-/** @defgroup ETH_Rx_Mode ETH Rx Mode
-  * @{
-  */ 
-#define ETH_RXPOLLING_MODE      ((uint32_t)0x00000000U)
-#define ETH_RXINTERRUPT_MODE    ((uint32_t)0x00000001U)
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Checksum_Mode ETH Checksum Mode
-  * @{
-  */ 
-#define ETH_CHECKSUM_BY_HARDWARE      ((uint32_t)0x00000000U)
-#define ETH_CHECKSUM_BY_SOFTWARE      ((uint32_t)0x00000001U)
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Media_Interface ETH Media Interface
-  * @{
-  */ 
-#define ETH_MEDIA_INTERFACE_MII       ((uint32_t)0x00000000U)
-#define ETH_MEDIA_INTERFACE_RMII      ((uint32_t)SYSCFG_PMC_MII_RMII_SEL)
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Watchdog ETH Watchdog 
-  * @{
-  */ 
-#define ETH_WATCHDOG_ENABLE       ((uint32_t)0x00000000U)
-#define ETH_WATCHDOG_DISABLE      ((uint32_t)0x00800000U)
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Jabber ETH Jabber
-  * @{
-  */ 
-#define ETH_JABBER_ENABLE    ((uint32_t)0x00000000U)
-#define ETH_JABBER_DISABLE   ((uint32_t)0x00400000U)
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Inter_Frame_Gap ETH Inter Frame Gap 
-  * @{
-  */ 
-#define ETH_INTERFRAMEGAP_96BIT   ((uint32_t)0x00000000U)  /*!< minimum IFG between frames during transmission is 96Bit */
-#define ETH_INTERFRAMEGAP_88BIT   ((uint32_t)0x00020000U)  /*!< minimum IFG between frames during transmission is 88Bit */
-#define ETH_INTERFRAMEGAP_80BIT   ((uint32_t)0x00040000U)  /*!< minimum IFG between frames during transmission is 80Bit */
-#define ETH_INTERFRAMEGAP_72BIT   ((uint32_t)0x00060000U)  /*!< minimum IFG between frames during transmission is 72Bit */
-#define ETH_INTERFRAMEGAP_64BIT   ((uint32_t)0x00080000U)  /*!< minimum IFG between frames during transmission is 64Bit */
-#define ETH_INTERFRAMEGAP_56BIT   ((uint32_t)0x000A0000U)  /*!< minimum IFG between frames during transmission is 56Bit */
-#define ETH_INTERFRAMEGAP_48BIT   ((uint32_t)0x000C0000U)  /*!< minimum IFG between frames during transmission is 48Bit */
-#define ETH_INTERFRAMEGAP_40BIT   ((uint32_t)0x000E0000U)  /*!< minimum IFG between frames during transmission is 40Bit */
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Carrier_Sense ETH Carrier Sense
-  * @{
-  */ 
-#define ETH_CARRIERSENCE_ENABLE   ((uint32_t)0x00000000U)
-#define ETH_CARRIERSENCE_DISABLE  ((uint32_t)0x00010000U)
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Receive_Own ETH Receive Own 
-  * @{
-  */ 
-#define ETH_RECEIVEOWN_ENABLE     ((uint32_t)0x00000000U)
-#define ETH_RECEIVEOWN_DISABLE    ((uint32_t)0x00002000U)
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Loop_Back_Mode ETH Loop Back Mode 
-  * @{
-  */ 
-#define ETH_LOOPBACKMODE_ENABLE        ((uint32_t)0x00001000U)
-#define ETH_LOOPBACKMODE_DISABLE       ((uint32_t)0x00000000U)
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Checksum_Offload ETH Checksum Offload
-  * @{
-  */ 
-#define ETH_CHECKSUMOFFLAOD_ENABLE     ((uint32_t)0x00000400U)
-#define ETH_CHECKSUMOFFLAOD_DISABLE    ((uint32_t)0x00000000U)
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Retry_Transmission ETH Retry Transmission
-  * @{
-  */ 
-#define ETH_RETRYTRANSMISSION_ENABLE   ((uint32_t)0x00000000U)
-#define ETH_RETRYTRANSMISSION_DISABLE  ((uint32_t)0x00000200U)
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Automatic_Pad_CRC_Strip ETH Automatic Pad CRC Strip
-  * @{
-  */ 
-#define ETH_AUTOMATICPADCRCSTRIP_ENABLE     ((uint32_t)0x00000080U)
-#define ETH_AUTOMATICPADCRCSTRIP_DISABLE    ((uint32_t)0x00000000U)
+#define ETH_FULLDUPLEX_MODE       ETH_MACCR_DM
+#define ETH_HALFDUPLEX_MODE       ((uint32_t)0x00000000U)
 /**
   * @}
   */
 
 /** @defgroup ETH_Back_Off_Limit ETH Back Off Limit
   * @{
-  */ 
-#define ETH_BACKOFFLIMIT_10  ((uint32_t)0x00000000U)
-#define ETH_BACKOFFLIMIT_8   ((uint32_t)0x00000020U)
-#define ETH_BACKOFFLIMIT_4   ((uint32_t)0x00000040U)
-#define ETH_BACKOFFLIMIT_1   ((uint32_t)0x00000060U)
+  */
+#define ETH_BACKOFFLIMIT_10  0x00000000U
+#define ETH_BACKOFFLIMIT_8   0x00000020U
+#define ETH_BACKOFFLIMIT_4   0x00000040U
+#define ETH_BACKOFFLIMIT_1   0x00000060U
 /**
   * @}
   */
 
-/** @defgroup ETH_Deferral_Check ETH Deferral Check
+/** @defgroup ETH_Preamble_Length ETH Preamble Length
   * @{
   */
-#define ETH_DEFFERRALCHECK_ENABLE       ((uint32_t)0x00000010U)
-#define ETH_DEFFERRALCHECK_DISABLE      ((uint32_t)0x00000000U)
+#define ETH_PREAMBLELENGTH_7      ETH_MACCR_PRELEN_7
+#define ETH_PREAMBLELENGTH_5      ETH_MACCR_PRELEN_5
+#define ETH_PREAMBLELENGTH_3      ETH_MACCR_PRELEN_3
 /**
   * @}
   */
 
-/** @defgroup ETH_Receive_All ETH Receive All
+/** @defgroup ETH_Source_Addr_Control ETH Source Addr Control
   * @{
-  */ 
-#define ETH_RECEIVEALL_ENABLE     ((uint32_t)0x80000000U)
-#define ETH_RECEIVEAll_DISABLE    ((uint32_t)0x00000000U)
+  */
+#define ETH_SOURCEADDRESS_DISABLE           ((uint32_t)0x00000000U)
+#define ETH_SOURCEADDRESS_INSERT_ADDR0      ETH_MACCR_SARC_INSADDR0
+#define ETH_SOURCEADDRESS_INSERT_ADDR1      ETH_MACCR_SARC_INSADDR1
+#define ETH_SOURCEADDRESS_REPLACE_ADDR0     ETH_MACCR_SARC_REPADDR0
+#define ETH_SOURCEADDRESS_REPLACE_ADDR1     ETH_MACCR_SARC_REPADDR1
 /**
   * @}
   */
 
-/** @defgroup ETH_Source_Addr_Filter ETH Source Addr Filter
+/** @defgroup ETH_Control_Packets_Filter ETH Control Packets Filter
   * @{
-  */ 
-#define ETH_SOURCEADDRFILTER_NORMAL_ENABLE       ((uint32_t)0x00000200U)
-#define ETH_SOURCEADDRFILTER_INVERSE_ENABLE      ((uint32_t)0x00000300U)
-#define ETH_SOURCEADDRFILTER_DISABLE             ((uint32_t)0x00000000U)
-/**
-  * @}
   */
-
-/** @defgroup ETH_Pass_Control_Frames ETH Pass Control Frames
-  * @{
-  */ 
-#define ETH_PASSCONTROLFRAMES_BLOCKALL                ((uint32_t)0x00000040U)  /*!< MAC filters all control frames from reaching the application */
-#define ETH_PASSCONTROLFRAMES_FORWARDALL              ((uint32_t)0x00000080U)  /*!< MAC forwards all control frames to application even if they fail the Address Filter */
-#define ETH_PASSCONTROLFRAMES_FORWARDPASSEDADDRFILTER ((uint32_t)0x000000C0U)  /*!< MAC forwards control frames that pass the Address Filter. */ 
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Broadcast_Frames_Reception ETH Broadcast Frames Reception
-  * @{
-  */ 
-#define ETH_BROADCASTFRAMESRECEPTION_ENABLE     ((uint32_t)0x00000000U)
-#define ETH_BROADCASTFRAMESRECEPTION_DISABLE    ((uint32_t)0x00000020U)
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Destination_Addr_Filter ETH Destination Addr Filter
-  * @{
-  */ 
-#define ETH_DESTINATIONADDRFILTER_NORMAL    ((uint32_t)0x00000000U)
-#define ETH_DESTINATIONADDRFILTER_INVERSE   ((uint32_t)0x00000008U)
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Promiscuous_Mode ETH Promiscuous Mode
-  * @{
-  */ 
-#define ETH_PROMISCUOUS_MODE_ENABLE     ((uint32_t)0x00000001U)
-#define ETH_PROMISCUOUS_MODE_DISABLE    ((uint32_t)0x00000000U)
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Multicast_Frames_Filter ETH Multicast Frames Filter
-  * @{
-  */ 
-#define ETH_MULTICASTFRAMESFILTER_PERFECTHASHTABLE    ((uint32_t)0x00000404U)
-#define ETH_MULTICASTFRAMESFILTER_HASHTABLE           ((uint32_t)0x00000004U)
-#define ETH_MULTICASTFRAMESFILTER_PERFECT             ((uint32_t)0x00000000U)
-#define ETH_MULTICASTFRAMESFILTER_NONE                ((uint32_t)0x00000010U)
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Unicast_Frames_Filter ETH Unicast Frames Filter
-  * @{
-  */ 
-#define ETH_UNICASTFRAMESFILTER_PERFECTHASHTABLE ((uint32_t)0x00000402U)
-#define ETH_UNICASTFRAMESFILTER_HASHTABLE        ((uint32_t)0x00000002U)
-#define ETH_UNICASTFRAMESFILTER_PERFECT          ((uint32_t)0x00000000U)
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Zero_Quanta_Pause ETH Zero Quanta Pause 
-  * @{
-  */ 
-#define ETH_ZEROQUANTAPAUSE_ENABLE     ((uint32_t)0x00000000U)
-#define ETH_ZEROQUANTAPAUSE_DISABLE    ((uint32_t)0x00000080U)
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Pause_Low_Threshold ETH Pause Low Threshold
-  * @{
-  */ 
-#define ETH_PAUSELOWTHRESHOLD_MINUS4        ((uint32_t)0x00000000U)  /*!< Pause time minus 4 slot times */
-#define ETH_PAUSELOWTHRESHOLD_MINUS28       ((uint32_t)0x00000010U)  /*!< Pause time minus 28 slot times */
-#define ETH_PAUSELOWTHRESHOLD_MINUS144      ((uint32_t)0x00000020U)  /*!< Pause time minus 144 slot times */
-#define ETH_PAUSELOWTHRESHOLD_MINUS256      ((uint32_t)0x00000030U)  /*!< Pause time minus 256 slot times */
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Unicast_Pause_Frame_Detect ETH Unicast Pause Frame Detect
-  * @{
-  */ 
-#define ETH_UNICASTPAUSEFRAMEDETECT_ENABLE  ((uint32_t)0x00000008U)
-#define ETH_UNICASTPAUSEFRAMEDETECT_DISABLE ((uint32_t)0x00000000U)
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Receive_Flow_Control ETH Receive Flow Control
-  * @{
-  */ 
-#define ETH_RECEIVEFLOWCONTROL_ENABLE       ((uint32_t)0x00000004U)
-#define ETH_RECEIVEFLOWCONTROL_DISABLE      ((uint32_t)0x00000000U)
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Transmit_Flow_Control ETH Transmit Flow Control
-  * @{
-  */ 
-#define ETH_TRANSMITFLOWCONTROL_ENABLE      ((uint32_t)0x00000002U)
-#define ETH_TRANSMITFLOWCONTROL_DISABLE     ((uint32_t)0x00000000U)
+#define ETH_CTRLPACKETS_BLOCK_ALL                      ETH_MACPFR_PCF_BLOCKALL
+#define ETH_CTRLPACKETS_FORWARD_ALL_EXCEPT_PA          ETH_MACPFR_PCF_FORWARDALLEXCEPTPA
+#define ETH_CTRLPACKETS_FORWARD_ALL                    ETH_MACPFR_PCF_FORWARDALL
+#define ETH_CTRLPACKETS_FORWARD_PASSED_ADDR_FILTER     ETH_MACPFR_PCF_FORWARDPASSEDADDRFILTER
 /**
   * @}
   */
 
 /** @defgroup ETH_VLAN_Tag_Comparison ETH VLAN Tag Comparison
   * @{
-  */ 
-#define ETH_VLANTAGCOMPARISON_12BIT    ((uint32_t)0x00010000U)
-#define ETH_VLANTAGCOMPARISON_16BIT    ((uint32_t)0x00000000U)
+  */
+#define ETH_VLANTAGCOMPARISON_12BIT    0x00010000U
+#define ETH_VLANTAGCOMPARISON_16BIT    0x00000000U
 /**
   * @}
   */
 
 /** @defgroup ETH_MAC_addresses ETH MAC addresses
   * @{
-  */ 
+  */
 #define ETH_MAC_ADDRESS0     ((uint32_t)0x00000000U)
 #define ETH_MAC_ADDRESS1     ((uint32_t)0x00000008U)
 #define ETH_MAC_ADDRESS2     ((uint32_t)0x00000010U)
@@ -1228,239 +1270,410 @@ typedef  void (*pETH_CallbackTypeDef)(ETH_HandleTypeDef * heth); /*!< pointer to
   * @}
   */
 
-/** @defgroup ETH_MAC_addresses_filter_SA_DA ETH MAC addresses filter SA DA 
+/** @defgroup ETH_MAC_Interrupts ETH MAC Interrupts
   * @{
-  */ 
-#define ETH_MAC_ADDRESSFILTER_SA       ((uint32_t)0x00000000U)
-#define ETH_MAC_ADDRESSFILTER_DA       ((uint32_t)0x00000008U)
+  */
+#define ETH_MAC_PMT_IT           ETH_MACSR_PMTS
+/**
+  * @}
+  */
+
+/** @defgroup ETH_MAC_Wake_Up_Event ETH MAC Wake Up Event
+  * @{
+  */
+#define ETH_WAKEUP_PACKET_RECIEVED    ETH_MACPCSR_RWKPRCVD
+#define ETH_MAGIC_PACKET_RECIEVED     ETH_MACPCSR_MGKPRCVD
+/**
+  * @}
+  */
+
+/** @defgroup ETH_MAC_Rx_Tx_Status ETH MAC Rx Tx Status
+  * @{
+  */
+#define ETH_RECEIVE_WATCHDOG_TIMEOUT        ETH_MACRXTXSR_RWT
+#define ETH_EXECESSIVE_COLLISIONS           ETH_MACRXTXSR_EXCOL
+#define ETH_LATE_COLLISIONS                 ETH_MACRXTXSR_LCOL
+#define ETH_EXECESSIVE_DEFERRAL             ETH_MACRXTXSR_EXDEF
+#define ETH_LOSS_OF_CARRIER                 ETH_MACRXTXSR_LCARR
+#define ETH_NO_CARRIER                      ETH_MACRXTXSR_NCARR
+#define ETH_TRANSMIT_JABBR_TIMEOUT          ETH_MACRXTXSR_TJT
+/**
+  * @}
+  */
+
+/** @defgroup HAL_ETH_StateTypeDef ETH States
+  * @{
+  */
+#define HAL_ETH_STATE_RESET       ((uint32_t)0x00000000U)    /*!< Peripheral not yet Initialized or disabled */
+#define HAL_ETH_STATE_READY       ((uint32_t)0x00000010U)    /*!< Peripheral Communication started           */
+#define HAL_ETH_STATE_BUSY        ((uint32_t)0x00000023U)    /*!< an internal process is ongoing             */
+#define HAL_ETH_STATE_STARTED     ((uint32_t)0x00000023U)    /*!< an internal process is started             */
+#define HAL_ETH_STATE_ERROR       ((uint32_t)0x000000E0U)    /*!< Error State                                */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_AutoNegotiation ETH AutoNegotiation
+  * @{
+  */
+#define ETH_AUTONEGOTIATION_ENABLE     0x00000001U
+#define ETH_AUTONEGOTIATION_DISABLE    0x00000000U
+
+/**
+  * @}
+  */
+/** @defgroup ETH_Rx_Mode ETH Rx Mode
+  * @{
+  */
+#define ETH_RXPOLLING_MODE      0x00000000U
+#define ETH_RXINTERRUPT_MODE    0x00000001U
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Checksum_Mode ETH Checksum Mode
+  * @{
+  */
+#define ETH_CHECKSUM_BY_HARDWARE      0x00000000U
+#define ETH_CHECKSUM_BY_SOFTWARE      0x00000001U
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Media_Interface ETH Media Interface
+  * @{
+  */
+#define ETH_MEDIA_INTERFACE_MII       0x00000000U
+#define ETH_MEDIA_INTERFACE_RMII      ((uint32_t)SYSCFG_PMC_MII_RMII_SEL)
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Watchdog ETH Watchdog
+  * @{
+  */
+#define ETH_WATCHDOG_ENABLE       0x00000000U
+#define ETH_WATCHDOG_DISABLE      0x00800000U
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Jabber ETH Jabber
+  * @{
+  */
+#define ETH_JABBER_ENABLE    0x00000000U
+#define ETH_JABBER_DISABLE   0x00400000U
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Inter_Frame_Gap ETH Inter Frame Gap
+  * @{
+  */
+#define ETH_INTERFRAMEGAP_96BIT   0x00000000U  /*!< minimum IFG between frames during transmission is 96Bit */
+#define ETH_INTERFRAMEGAP_88BIT   0x00020000U  /*!< minimum IFG between frames during transmission is 88Bit */
+#define ETH_INTERFRAMEGAP_80BIT   0x00040000U  /*!< minimum IFG between frames during transmission is 80Bit */
+#define ETH_INTERFRAMEGAP_72BIT   0x00060000U  /*!< minimum IFG between frames during transmission is 72Bit */
+#define ETH_INTERFRAMEGAP_64BIT   0x00080000U  /*!< minimum IFG between frames during transmission is 64Bit */
+#define ETH_INTERFRAMEGAP_56BIT   0x000A0000U  /*!< minimum IFG between frames during transmission is 56Bit */
+#define ETH_INTERFRAMEGAP_48BIT   0x000C0000U  /*!< minimum IFG between frames during transmission is 48Bit */
+#define ETH_INTERFRAMEGAP_40BIT   0x000E0000U  /*!< minimum IFG between frames during transmission is 40Bit */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Carrier_Sense ETH Carrier Sense
+  * @{
+  */
+#define ETH_CARRIERSENCE_ENABLE   0x00000000U
+#define ETH_CARRIERSENCE_DISABLE  0x00010000U
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Receive_Own ETH Receive Own
+  * @{
+  */
+#define ETH_RECEIVEOWN_ENABLE     0x00000000U
+#define ETH_RECEIVEOWN_DISABLE    0x00002000U
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Loop_Back_Mode ETH Loop Back Mode
+  * @{
+  */
+#define ETH_LOOPBACKMODE_ENABLE        0x00001000U
+#define ETH_LOOPBACKMODE_DISABLE       0x00000000U
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Checksum_Offload ETH Checksum Offload
+  * @{
+  */
+#define ETH_CHECKSUMOFFLAOD_ENABLE     0x00000400U
+#define ETH_CHECKSUMOFFLAOD_DISABLE    0x00000000U
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Retry_Transmission ETH Retry Transmission
+  * @{
+  */
+#define ETH_RETRYTRANSMISSION_ENABLE   0x00000000U
+#define ETH_RETRYTRANSMISSION_DISABLE  0x00000200U
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Automatic_Pad_CRC_Strip ETH Automatic Pad CRC Strip
+  * @{
+  */
+#define ETH_AUTOMATICPADCRCSTRIP_ENABLE     0x00000080U
+#define ETH_AUTOMATICPADCRCSTRIP_DISABLE    0x00000000U
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Deferral_Check ETH Deferral Check
+  * @{
+  */
+#define ETH_DEFFERRALCHECK_ENABLE       0x00000010U
+#define ETH_DEFFERRALCHECK_DISABLE      0x00000000U
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Receive_All ETH Receive All
+  * @{
+  */
+#define ETH_RECEIVEALL_ENABLE     0x80000000U
+#define ETH_RECEIVEALL_DISABLE    0x00000000U
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Source_Addr_Filter ETH Source Addr Filter
+  * @{
+  */
+#define ETH_SOURCEADDRFILTER_NORMAL_ENABLE       0x00000200U
+#define ETH_SOURCEADDRFILTER_INVERSE_ENABLE      0x00000300U
+#define ETH_SOURCEADDRFILTER_DISABLE             0x00000000U
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Pass_Control_Frames ETH Pass Control Frames
+  * @{
+  */
+#define ETH_PASSCONTROLFRAMES_BLOCKALL                0x00000040U  /*!< MAC filters all control frames from reaching the application */
+#define ETH_PASSCONTROLFRAMES_FORWARDALL              0x00000080U  /*!< MAC forwards all control frames to application even if they fail the Address Filter */
+#define ETH_PASSCONTROLFRAMES_FORWARDPASSEDADDRFILTER 0x000000C0U  /*!< MAC forwards control frames that pass the Address Filter. */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Broadcast_Frames_Reception ETH Broadcast Frames Reception
+  * @{
+  */
+#define ETH_BROADCASTFRAMESRECEPTION_ENABLE     0x00000000U
+#define ETH_BROADCASTFRAMESRECEPTION_DISABLE    0x00000020U
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Destination_Addr_Filter ETH Destination Addr Filter
+  * @{
+  */
+#define ETH_DESTINATIONADDRFILTER_NORMAL    0x00000000U
+#define ETH_DESTINATIONADDRFILTER_INVERSE   0x00000008U
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Promiscuous_Mode ETH Promiscuous Mode
+  * @{
+  */
+#define ETH_PROMISCUOUS_MODE_ENABLE     0x00000001U
+#define ETH_PROMISCUOUS_MODE_DISABLE    0x00000000U
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Multicast_Frames_Filter ETH Multicast Frames Filter
+  * @{
+  */
+#define ETH_MULTICASTFRAMESFILTER_PERFECTHASHTABLE    0x00000404U
+#define ETH_MULTICASTFRAMESFILTER_HASHTABLE           0x00000004U
+#define ETH_MULTICASTFRAMESFILTER_PERFECT             0x00000000U
+#define ETH_MULTICASTFRAMESFILTER_NONE                0x00000010U
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Unicast_Frames_Filter ETH Unicast Frames Filter
+  * @{
+  */
+#define ETH_UNICASTFRAMESFILTER_PERFECTHASHTABLE 0x00000402U
+#define ETH_UNICASTFRAMESFILTER_HASHTABLE        0x00000002U
+#define ETH_UNICASTFRAMESFILTER_PERFECT          0x00000000U
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Zero_Quanta_Pause ETH Zero Quanta Pause
+  * @{
+  */
+#define ETH_ZEROQUANTAPAUSE_ENABLE     0x00000000U
+#define ETH_ZEROQUANTAPAUSE_DISABLE    0x00000080U
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Pause_Low_Threshold ETH Pause Low Threshold
+  * @{
+  */
+#define ETH_PAUSELOWTHRESHOLD_MINUS4        0x00000000U  /*!< Pause time minus 4 slot times */
+#define ETH_PAUSELOWTHRESHOLD_MINUS28       0x00000010U  /*!< Pause time minus 28 slot times */
+#define ETH_PAUSELOWTHRESHOLD_MINUS144      0x00000020U  /*!< Pause time minus 144 slot times */
+#define ETH_PAUSELOWTHRESHOLD_MINUS256      0x00000030U  /*!< Pause time minus 256 slot times */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Unicast_Pause_Frame_Detect ETH Unicast Pause Frame Detect
+  * @{
+  */
+#define ETH_UNICASTPAUSEFRAMEDETECT_ENABLE  0x00000008U
+#define ETH_UNICASTPAUSEFRAMEDETECT_DISABLE 0x00000000U
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Receive_Flow_Control ETH Receive Flow Control
+  * @{
+  */
+#define ETH_RECEIVEFLOWCONTROL_ENABLE       0x00000004U
+#define ETH_RECEIVEFLOWCONTROL_DISABLE      0x00000000U
+/**
+  * @}
+  */
+
+/** @defgroup ETH_Transmit_Flow_Control ETH Transmit Flow Control
+  * @{
+  */
+#define ETH_TRANSMITFLOWCONTROL_ENABLE      0x00000002U
+#define ETH_TRANSMITFLOWCONTROL_DISABLE     0x00000000U
+/**
+  * @}
+  */
+
+/** @defgroup ETH_MAC_addresses_filter_SA_DA ETH MAC addresses filter SA DA
+  * @{
+  */
+#define ETH_MAC_ADDRESSFILTER_SA       0x00000000U
+#define ETH_MAC_ADDRESSFILTER_DA       0x00000008U
 /**
   * @}
   */
 
 /** @defgroup ETH_MAC_addresses_filter_Mask_bytes ETH MAC addresses filter Mask bytes
   * @{
-  */ 
-#define ETH_MAC_ADDRESSMASK_BYTE6      ((uint32_t)0x20000000U)  /*!< Mask MAC Address high reg bits [15:8] */
-#define ETH_MAC_ADDRESSMASK_BYTE5      ((uint32_t)0x10000000U)  /*!< Mask MAC Address high reg bits [7:0] */
-#define ETH_MAC_ADDRESSMASK_BYTE4      ((uint32_t)0x08000000U)  /*!< Mask MAC Address low reg bits [31:24] */
-#define ETH_MAC_ADDRESSMASK_BYTE3      ((uint32_t)0x04000000U)  /*!< Mask MAC Address low reg bits [23:16] */
-#define ETH_MAC_ADDRESSMASK_BYTE2      ((uint32_t)0x02000000U)  /*!< Mask MAC Address low reg bits [15:8] */
-#define ETH_MAC_ADDRESSMASK_BYTE1      ((uint32_t)0x01000000U)  /*!< Mask MAC Address low reg bits [70] */
-/**
-  * @}
   */
-
-/** @defgroup ETH_Drop_TCP_IP_Checksum_Error_Frame ETH Drop TCP IP Checksum Error Frame
-  * @{
-  */ 
-#define ETH_DROPTCPIPCHECKSUMERRORFRAME_ENABLE   ((uint32_t)0x00000000U)
-#define ETH_DROPTCPIPCHECKSUMERRORFRAME_DISABLE  ((uint32_t)0x04000000U)
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Receive_Store_Forward ETH Receive Store Forward
-  * @{
-  */ 
-#define ETH_RECEIVESTOREFORWARD_ENABLE      ((uint32_t)0x02000000U)
-#define ETH_RECEIVESTOREFORWARD_DISABLE     ((uint32_t)0x00000000U)
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Flush_Received_Frame ETH Flush Received Frame
-  * @{
-  */ 
-#define ETH_FLUSHRECEIVEDFRAME_ENABLE       ((uint32_t)0x00000000U)
-#define ETH_FLUSHRECEIVEDFRAME_DISABLE      ((uint32_t)0x01000000U)
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Transmit_Store_Forward ETH Transmit Store Forward
-  * @{
-  */ 
-#define ETH_TRANSMITSTOREFORWARD_ENABLE     ((uint32_t)0x00200000U)
-#define ETH_TRANSMITSTOREFORWARD_DISABLE    ((uint32_t)0x00000000U)
+#define ETH_MAC_ADDRESSMASK_BYTE6      0x20000000U  /*!< Mask MAC Address high reg bits [15:8] */
+#define ETH_MAC_ADDRESSMASK_BYTE5      0x10000000U  /*!< Mask MAC Address high reg bits [7:0] */
+#define ETH_MAC_ADDRESSMASK_BYTE4      0x08000000U  /*!< Mask MAC Address low reg bits [31:24] */
+#define ETH_MAC_ADDRESSMASK_BYTE3      0x04000000U  /*!< Mask MAC Address low reg bits [23:16] */
+#define ETH_MAC_ADDRESSMASK_BYTE2      0x02000000U  /*!< Mask MAC Address low reg bits [15:8] */
+#define ETH_MAC_ADDRESSMASK_BYTE1      0x01000000U  /*!< Mask MAC Address low reg bits [70] */
 /**
   * @}
   */
 
 /** @defgroup ETH_Transmit_Threshold_Control ETH Transmit Threshold Control
   * @{
-  */ 
-#define ETH_TRANSMITTHRESHOLDCONTROL_64BYTES     ((uint32_t)0x00000000U)  /*!< threshold level of the MTL Transmit FIFO is 64 Bytes */
-#define ETH_TRANSMITTHRESHOLDCONTROL_128BYTES    ((uint32_t)0x00004000U)  /*!< threshold level of the MTL Transmit FIFO is 128 Bytes */
-#define ETH_TRANSMITTHRESHOLDCONTROL_192BYTES    ((uint32_t)0x00008000U)  /*!< threshold level of the MTL Transmit FIFO is 192 Bytes */
-#define ETH_TRANSMITTHRESHOLDCONTROL_256BYTES    ((uint32_t)0x0000C000U)  /*!< threshold level of the MTL Transmit FIFO is 256 Bytes */
-#define ETH_TRANSMITTHRESHOLDCONTROL_40BYTES     ((uint32_t)0x00010000U)  /*!< threshold level of the MTL Transmit FIFO is 40 Bytes */
-#define ETH_TRANSMITTHRESHOLDCONTROL_32BYTES     ((uint32_t)0x00014000U)  /*!< threshold level of the MTL Transmit FIFO is 32 Bytes */
-#define ETH_TRANSMITTHRESHOLDCONTROL_24BYTES     ((uint32_t)0x00018000U)  /*!< threshold level of the MTL Transmit FIFO is 24 Bytes */
-#define ETH_TRANSMITTHRESHOLDCONTROL_16BYTES     ((uint32_t)0x0001C000U)  /*!< threshold level of the MTL Transmit FIFO is 16 Bytes */
-/**
-  * @}
   */
-
-/** @defgroup ETH_Forward_Error_Frames ETH Forward Error Frames
-  * @{
-  */ 
-#define ETH_FORWARDERRORFRAMES_ENABLE       ((uint32_t)0x00000080U)
-#define ETH_FORWARDERRORFRAMES_DISABLE      ((uint32_t)0x00000000U)
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Forward_Undersized_Good_Frames ETH Forward Undersized Good Frames
-  * @{
-  */ 
-#define ETH_FORWARDUNDERSIZEDGOODFRAMES_ENABLE   ((uint32_t)0x00000040U)
-#define ETH_FORWARDUNDERSIZEDGOODFRAMES_DISABLE  ((uint32_t)0x00000000U)     
+#define ETH_TRANSMITTHRESHOLDCONTROL_64BYTES     0x00000000U  /*!< threshold level of the MTL Transmit FIFO is 64 Bytes */
+#define ETH_TRANSMITTHRESHOLDCONTROL_128BYTES    0x00004000U  /*!< threshold level of the MTL Transmit FIFO is 128 Bytes */
+#define ETH_TRANSMITTHRESHOLDCONTROL_192BYTES    0x00008000U  /*!< threshold level of the MTL Transmit FIFO is 192 Bytes */
+#define ETH_TRANSMITTHRESHOLDCONTROL_256BYTES    0x0000C000U  /*!< threshold level of the MTL Transmit FIFO is 256 Bytes */
+#define ETH_TRANSMITTHRESHOLDCONTROL_40BYTES     0x00010000U  /*!< threshold level of the MTL Transmit FIFO is 40 Bytes */
+#define ETH_TRANSMITTHRESHOLDCONTROL_32BYTES     0x00014000U  /*!< threshold level of the MTL Transmit FIFO is 32 Bytes */
+#define ETH_TRANSMITTHRESHOLDCONTROL_24BYTES     0x00018000U  /*!< threshold level of the MTL Transmit FIFO is 24 Bytes */
+#define ETH_TRANSMITTHRESHOLDCONTROL_16BYTES     0x0001C000U  /*!< threshold level of the MTL Transmit FIFO is 16 Bytes */
 /**
   * @}
   */
 
 /** @defgroup ETH_Receive_Threshold_Control ETH Receive Threshold Control
   * @{
-  */ 
-#define ETH_RECEIVEDTHRESHOLDCONTROL_64BYTES      ((uint32_t)0x00000000U)  /*!< threshold level of the MTL Receive FIFO is 64 Bytes */
-#define ETH_RECEIVEDTHRESHOLDCONTROL_32BYTES      ((uint32_t)0x00000008U)  /*!< threshold level of the MTL Receive FIFO is 32 Bytes */
-#define ETH_RECEIVEDTHRESHOLDCONTROL_96BYTES      ((uint32_t)0x00000010U)  /*!< threshold level of the MTL Receive FIFO is 96 Bytes */
-#define ETH_RECEIVEDTHRESHOLDCONTROL_128BYTES     ((uint32_t)0x00000018U)  /*!< threshold level of the MTL Receive FIFO is 128 Bytes */
-/**
-  * @}
   */
-
-/** @defgroup ETH_Second_Frame_Operate ETH Second Frame Operate
-  * @{
-  */ 
-#define ETH_SECONDFRAMEOPERARTE_ENABLE       ((uint32_t)0x00000004U)
-#define ETH_SECONDFRAMEOPERARTE_DISABLE      ((uint32_t)0x00000000U)  
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Address_Aligned_Beats ETH Address Aligned Beats 
-  * @{
-  */ 
-#define ETH_ADDRESSALIGNEDBEATS_ENABLE      ((uint32_t)0x02000000U)
-#define ETH_ADDRESSALIGNEDBEATS_DISABLE     ((uint32_t)0x00000000U) 
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Fixed_Burst ETH Fixed Burst
-  * @{
-  */ 
-#define ETH_FIXEDBURST_ENABLE     ((uint32_t)0x00010000U)
-#define ETH_FIXEDBURST_DISABLE    ((uint32_t)0x00000000U) 
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Rx_DMA_Burst_Length ETH Rx DMA Burst Length
-  * @{
-  */ 
-#define ETH_RXDMABURSTLENGTH_1BEAT          ((uint32_t)0x00020000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 1 */
-#define ETH_RXDMABURSTLENGTH_2BEAT          ((uint32_t)0x00040000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 2 */
-#define ETH_RXDMABURSTLENGTH_4BEAT          ((uint32_t)0x00080000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 4 */
-#define ETH_RXDMABURSTLENGTH_8BEAT          ((uint32_t)0x00100000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 8 */
-#define ETH_RXDMABURSTLENGTH_16BEAT         ((uint32_t)0x00200000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 16 */
-#define ETH_RXDMABURSTLENGTH_32BEAT         ((uint32_t)0x00400000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 32 */                
-#define ETH_RXDMABURSTLENGTH_4XPBL_4BEAT    ((uint32_t)0x01020000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 4 */
-#define ETH_RXDMABURSTLENGTH_4XPBL_8BEAT    ((uint32_t)0x01040000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 8 */
-#define ETH_RXDMABURSTLENGTH_4XPBL_16BEAT   ((uint32_t)0x01080000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 16 */
-#define ETH_RXDMABURSTLENGTH_4XPBL_32BEAT   ((uint32_t)0x01100000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 32 */
-#define ETH_RXDMABURSTLENGTH_4XPBL_64BEAT   ((uint32_t)0x01200000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 64 */
-#define ETH_RXDMABURSTLENGTH_4XPBL_128BEAT  ((uint32_t)0x01400000U)  /*!< maximum number of beats to be transferred in one RxDMA transaction is 128 */
-/**
-  * @}
-  */
-
-/** @defgroup ETH_Tx_DMA_Burst_Length ETH Tx DMA Burst Length
-  * @{
-  */ 
-#define ETH_TXDMABURSTLENGTH_1BEAT          ((uint32_t)0x00000100U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 1 */
-#define ETH_TXDMABURSTLENGTH_2BEAT          ((uint32_t)0x00000200U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 2 */
-#define ETH_TXDMABURSTLENGTH_4BEAT          ((uint32_t)0x00000400U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
-#define ETH_TXDMABURSTLENGTH_8BEAT          ((uint32_t)0x00000800U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
-#define ETH_TXDMABURSTLENGTH_16BEAT         ((uint32_t)0x00001000U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
-#define ETH_TXDMABURSTLENGTH_32BEAT         ((uint32_t)0x00002000U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */                
-#define ETH_TXDMABURSTLENGTH_4XPBL_4BEAT    ((uint32_t)0x01000100U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
-#define ETH_TXDMABURSTLENGTH_4XPBL_8BEAT    ((uint32_t)0x01000200U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
-#define ETH_TXDMABURSTLENGTH_4XPBL_16BEAT   ((uint32_t)0x01000400U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
-#define ETH_TXDMABURSTLENGTH_4XPBL_32BEAT   ((uint32_t)0x01000800U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
-#define ETH_TXDMABURSTLENGTH_4XPBL_64BEAT   ((uint32_t)0x01001000U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 64 */
-#define ETH_TXDMABURSTLENGTH_4XPBL_128BEAT  ((uint32_t)0x01002000U)  /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 128 */
-/**
-  * @}
-  */
-
-/** @defgroup ETH_DMA_Enhanced_descriptor_format ETH DMA Enhanced descriptor format
-  * @{
-  */  
-#define ETH_DMAENHANCEDDESCRIPTOR_ENABLE              ((uint32_t)0x00000080U)
-#define ETH_DMAENHANCEDDESCRIPTOR_DISABLE             ((uint32_t)0x00000000U)
+#define ETH_RECEIVEDTHRESHOLDCONTROL_64BYTES      0x00000000U  /*!< threshold level of the MTL Receive FIFO is 64 Bytes */
+#define ETH_RECEIVEDTHRESHOLDCONTROL_32BYTES      0x00000008U  /*!< threshold level of the MTL Receive FIFO is 32 Bytes */
+#define ETH_RECEIVEDTHRESHOLDCONTROL_96BYTES      0x00000010U  /*!< threshold level of the MTL Receive FIFO is 96 Bytes */
+#define ETH_RECEIVEDTHRESHOLDCONTROL_128BYTES     0x00000018U  /*!< threshold level of the MTL Receive FIFO is 128 Bytes */
 /**
   * @}
   */
 
 /** @defgroup ETH_DMA_Arbitration ETH DMA Arbitration
   * @{
-  */ 
-#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_1_1   ((uint32_t)0x00000000U)
-#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_2_1   ((uint32_t)0x00004000U)
-#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_3_1   ((uint32_t)0x00008000U)
-#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_4_1   ((uint32_t)0x0000C000U)
-#define ETH_DMAARBITRATION_RXPRIORTX             ((uint32_t)0x00000002U)
+  */
+#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_1_1   0x00000000U
+#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_2_1   0x00004000U
+#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_3_1   0x00008000U
+#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_4_1   0x0000C000U
+#define ETH_DMAARBITRATION_RXPRIORTX             0x00000002U
 /**
   * @}
   */
 
 /** @defgroup ETH_DMA_Tx_descriptor_segment ETH DMA Tx descriptor segment
   * @{
-  */ 
-#define ETH_DMATXDESC_LASTSEGMENTS      ((uint32_t)0x40000000U)  /*!< Last Segment */
-#define ETH_DMATXDESC_FIRSTSEGMENT      ((uint32_t)0x20000000U)  /*!< First Segment */
+  */
+#define ETH_DMATXDESC_LASTSEGMENTS      0x40000000U  /*!< Last Segment */
+#define ETH_DMATXDESC_FIRSTSEGMENT      0x20000000U  /*!< First Segment */
 /**
   * @}
   */
 
 /** @defgroup ETH_DMA_Tx_descriptor_Checksum_Insertion_Control ETH DMA Tx descriptor Checksum Insertion Control
   * @{
-  */ 
-#define ETH_DMATXDESC_CHECKSUMBYPASS             ((uint32_t)0x00000000U)   /*!< Checksum engine bypass */
-#define ETH_DMATXDESC_CHECKSUMIPV4HEADER         ((uint32_t)0x00400000U)   /*!< IPv4 header checksum insertion  */
-#define ETH_DMATXDESC_CHECKSUMTCPUDPICMPSEGMENT  ((uint32_t)0x00800000U)   /*!< TCP/UDP/ICMP checksum insertion. Pseudo header checksum is assumed to be present */
-#define ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL     ((uint32_t)0x00C00000U)   /*!< TCP/UDP/ICMP checksum fully in hardware including pseudo header */
+  */
+#define ETH_DMATXDESC_CHECKSUMBYPASS             0x00000000U   /*!< Checksum engine bypass */
+#define ETH_DMATXDESC_CHECKSUMIPV4HEADER         0x00400000U   /*!< IPv4 header checksum insertion  */
+#define ETH_DMATXDESC_CHECKSUMTCPUDPICMPSEGMENT  0x00800000U   /*!< TCP/UDP/ICMP checksum insertion. Pseudo header checksum is assumed to be present */
+#define ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL     0x00C00000U   /*!< TCP/UDP/ICMP checksum fully in hardware including pseudo header */
 /**
   * @}
   */
 
-/** @defgroup ETH_DMA_Rx_descriptor_buffers ETH DMA Rx descriptor buffers 
+/** @defgroup ETH_DMA_Rx_descriptor_buffers ETH DMA Rx descriptor buffers
   * @{
-  */ 
-#define ETH_DMARXDESC_BUFFER1     ((uint32_t)0x00000000U)  /*!< DMA Rx Desc Buffer1 */
-#define ETH_DMARXDESC_BUFFER2     ((uint32_t)0x00000001U)  /*!< DMA Rx Desc Buffer2 */
+  */
+#define ETH_DMARXDESC_BUFFER1     0x00000000U  /*!< DMA Rx Desc Buffer1 */
+#define ETH_DMARXDESC_BUFFER2     0x00000001U  /*!< DMA Rx Desc Buffer2 */
 /**
   * @}
   */
 
 /** @defgroup ETH_PMT_Flags ETH PMT Flags
   * @{
-  */ 
-#define ETH_PMT_FLAG_WUFFRPR      ((uint32_t)0x80000000U)  /*!< Wake-Up Frame Filter Register Pointer Reset */
-#define ETH_PMT_FLAG_WUFR         ((uint32_t)0x00000040U)  /*!< Wake-Up Frame Received */
-#define ETH_PMT_FLAG_MPR          ((uint32_t)0x00000020U)  /*!< Magic Packet Received */
+  */
+#define ETH_PMT_FLAG_WUFFRPR      0x80000000U  /*!< Wake-Up Frame Filter Register Pointer Reset */
+#define ETH_PMT_FLAG_WUFR         0x00000040U  /*!< Wake-Up Frame Received */
+#define ETH_PMT_FLAG_MPR          0x00000020U  /*!< Magic Packet Received */
 /**
   * @}
   */
 
 /** @defgroup ETH_MMC_Tx_Interrupts ETH MMC Tx Interrupts
   * @{
-  */ 
-#define ETH_MMC_IT_TGF       ((uint32_t)0x00200000U)  /*!< When Tx good frame counter reaches half the maximum value */
-#define ETH_MMC_IT_TGFMSC    ((uint32_t)0x00008000U)  /*!< When Tx good multi col counter reaches half the maximum value */
-#define ETH_MMC_IT_TGFSC     ((uint32_t)0x00004000U)  /*!< When Tx good single col counter reaches half the maximum value */
+  */
+#define ETH_MMC_IT_TGF       0x00200000U  /*!< When Tx good frame counter reaches half the maximum value */
+#define ETH_MMC_IT_TGFMSC    0x00008000U  /*!< When Tx good multi col counter reaches half the maximum value */
+#define ETH_MMC_IT_TGFSC     0x00004000U  /*!< When Tx good single col counter reaches half the maximum value */
 /**
   * @}
   */
@@ -1468,114 +1681,114 @@ typedef  void (*pETH_CallbackTypeDef)(ETH_HandleTypeDef * heth); /*!< pointer to
 /** @defgroup ETH_MMC_Rx_Interrupts ETH MMC Rx Interrupts
   * @{
   */
-#define ETH_MMC_IT_RGUF      ((uint32_t)0x10020000U)  /*!< When Rx good unicast frames counter reaches half the maximum value */
-#define ETH_MMC_IT_RFAE      ((uint32_t)0x10000040U)  /*!< When Rx alignment error counter reaches half the maximum value */
-#define ETH_MMC_IT_RFCE      ((uint32_t)0x10000020U)  /*!< When Rx crc error counter reaches half the maximum value */
+#define ETH_MMC_IT_RGUF      0x10020000U  /*!< When Rx good unicast frames counter reaches half the maximum value */
+#define ETH_MMC_IT_RFAE      0x10000040U  /*!< When Rx alignment error counter reaches half the maximum value */
+#define ETH_MMC_IT_RFCE      0x10000020U  /*!< When Rx crc error counter reaches half the maximum value */
 /**
   * @}
   */
 
 /** @defgroup ETH_MAC_Flags ETH MAC Flags
   * @{
-  */ 
-#define ETH_MAC_FLAG_TST     ((uint32_t)0x00000200U)  /*!< Time stamp trigger flag (on MAC) */
-#define ETH_MAC_FLAG_MMCT    ((uint32_t)0x00000040U)  /*!< MMC transmit flag  */
-#define ETH_MAC_FLAG_MMCR    ((uint32_t)0x00000020U)  /*!< MMC receive flag */
-#define ETH_MAC_FLAG_MMC     ((uint32_t)0x00000010U)  /*!< MMC flag (on MAC) */
-#define ETH_MAC_FLAG_PMT     ((uint32_t)0x00000008U)  /*!< PMT flag (on MAC) */
+  */
+#define ETH_MAC_FLAG_TST     0x00000200U  /*!< Time stamp trigger flag (on MAC) */
+#define ETH_MAC_FLAG_MMCT    0x00000040U  /*!< MMC transmit flag  */
+#define ETH_MAC_FLAG_MMCR    0x00000020U  /*!< MMC receive flag */
+#define ETH_MAC_FLAG_MMC     0x00000010U  /*!< MMC flag (on MAC) */
+#define ETH_MAC_FLAG_PMT     0x00000008U  /*!< PMT flag (on MAC) */
 /**
   * @}
   */
 
 /** @defgroup ETH_DMA_Flags ETH DMA Flags
   * @{
-  */ 
-#define ETH_DMA_FLAG_TST               ((uint32_t)0x20000000U)  /*!< Time-stamp trigger interrupt (on DMA) */
-#define ETH_DMA_FLAG_PMT               ((uint32_t)0x10000000U)  /*!< PMT interrupt (on DMA) */
-#define ETH_DMA_FLAG_MMC               ((uint32_t)0x08000000U)  /*!< MMC interrupt (on DMA) */
-#define ETH_DMA_FLAG_DATATRANSFERERROR ((uint32_t)0x00800000U)  /*!< Error bits 0-Rx DMA, 1-Tx DMA */
-#define ETH_DMA_FLAG_READWRITEERROR    ((uint32_t)0x01000000U)  /*!< Error bits 0-write transfer, 1-read transfer */
-#define ETH_DMA_FLAG_ACCESSERROR       ((uint32_t)0x02000000U)  /*!< Error bits 0-data buffer, 1-desc. access */
-#define ETH_DMA_FLAG_NIS               ((uint32_t)0x00010000U)  /*!< Normal interrupt summary flag */
-#define ETH_DMA_FLAG_AIS               ((uint32_t)0x00008000U)  /*!< Abnormal interrupt summary flag */
-#define ETH_DMA_FLAG_ER                ((uint32_t)0x00004000U)  /*!< Early receive flag */
-#define ETH_DMA_FLAG_FBE               ((uint32_t)0x00002000U)  /*!< Fatal bus error flag */
-#define ETH_DMA_FLAG_ET                ((uint32_t)0x00000400U)  /*!< Early transmit flag */
-#define ETH_DMA_FLAG_RWT               ((uint32_t)0x00000200U)  /*!< Receive watchdog timeout flag */
-#define ETH_DMA_FLAG_RPS               ((uint32_t)0x00000100U)  /*!< Receive process stopped flag */
-#define ETH_DMA_FLAG_RBU               ((uint32_t)0x00000080U)  /*!< Receive buffer unavailable flag */
-#define ETH_DMA_FLAG_R                 ((uint32_t)0x00000040U)  /*!< Receive flag */
-#define ETH_DMA_FLAG_TU                ((uint32_t)0x00000020U)  /*!< Underflow flag */
-#define ETH_DMA_FLAG_RO                ((uint32_t)0x00000010U)  /*!< Overflow flag */
-#define ETH_DMA_FLAG_TJT               ((uint32_t)0x00000008U)  /*!< Transmit jabber timeout flag */
-#define ETH_DMA_FLAG_TBU               ((uint32_t)0x00000004U)  /*!< Transmit buffer unavailable flag */
-#define ETH_DMA_FLAG_TPS               ((uint32_t)0x00000002U)  /*!< Transmit process stopped flag */
-#define ETH_DMA_FLAG_T                 ((uint32_t)0x00000001U)  /*!< Transmit flag */
+  */
+#define ETH_DMA_FLAG_TST               0x20000000U  /*!< Time-stamp trigger interrupt (on DMA) */
+#define ETH_DMA_FLAG_PMT               0x10000000U  /*!< PMT interrupt (on DMA) */
+#define ETH_DMA_FLAG_MMC               0x08000000U  /*!< MMC interrupt (on DMA) */
+#define ETH_DMA_FLAG_DATATRANSFERERROR 0x00800000U  /*!< Error bits 0-Rx DMA, 1-Tx DMA */
+#define ETH_DMA_FLAG_READWRITEERROR    0x01000000U  /*!< Error bits 0-write transfer, 1-read transfer */
+#define ETH_DMA_FLAG_ACCESSERROR       0x02000000U  /*!< Error bits 0-data buffer, 1-desc. access */
+#define ETH_DMA_FLAG_NIS               0x00010000U  /*!< Normal interrupt summary flag */
+#define ETH_DMA_FLAG_AIS               0x00008000U  /*!< Abnormal interrupt summary flag */
+#define ETH_DMA_FLAG_ER                0x00004000U  /*!< Early receive flag */
+#define ETH_DMA_FLAG_FBE               0x00002000U  /*!< Fatal bus error flag */
+#define ETH_DMA_FLAG_ET                0x00000400U  /*!< Early transmit flag */
+#define ETH_DMA_FLAG_RWT               0x00000200U  /*!< Receive watchdog timeout flag */
+#define ETH_DMA_FLAG_RPS               0x00000100U  /*!< Receive process stopped flag */
+#define ETH_DMA_FLAG_RBU               0x00000080U  /*!< Receive buffer unavailable flag */
+#define ETH_DMA_FLAG_R                 0x00000040U  /*!< Receive flag */
+#define ETH_DMA_FLAG_TU                0x00000020U  /*!< Underflow flag */
+#define ETH_DMA_FLAG_RO                0x00000010U  /*!< Overflow flag */
+#define ETH_DMA_FLAG_TJT               0x00000008U  /*!< Transmit jabber timeout flag */
+#define ETH_DMA_FLAG_TBU               0x00000004U  /*!< Transmit buffer unavailable flag */
+#define ETH_DMA_FLAG_TPS               0x00000002U  /*!< Transmit process stopped flag */
+#define ETH_DMA_FLAG_T                 0x00000001U  /*!< Transmit flag */
 /**
   * @}
   */
 
-/** @defgroup ETH_MAC_Interrupts ETH MAC Interrupts 
+/** @defgroup ETH_MAC_Interrupts ETH MAC Interrupts
   * @{
-  */ 
-#define ETH_MAC_IT_TST       ((uint32_t)0x00000200U)  /*!< Time stamp trigger interrupt (on MAC) */
-#define ETH_MAC_IT_MMCT      ((uint32_t)0x00000040U)  /*!< MMC transmit interrupt */
-#define ETH_MAC_IT_MMCR      ((uint32_t)0x00000020U)  /*!< MMC receive interrupt */
-#define ETH_MAC_IT_MMC       ((uint32_t)0x00000010U)  /*!< MMC interrupt (on MAC) */
-#define ETH_MAC_IT_PMT       ((uint32_t)0x00000008U)  /*!< PMT interrupt (on MAC) */
+  */
+#define ETH_MAC_IT_TST       0x00000200U  /*!< Time stamp trigger interrupt (on MAC) */
+#define ETH_MAC_IT_MMCT      0x00000040U  /*!< MMC transmit interrupt */
+#define ETH_MAC_IT_MMCR      0x00000020U  /*!< MMC receive interrupt */
+#define ETH_MAC_IT_MMC       0x00000010U  /*!< MMC interrupt (on MAC) */
+#define ETH_MAC_IT_PMT       0x00000008U  /*!< PMT interrupt (on MAC) */
 /**
   * @}
   */
 
-/** @defgroup ETH_DMA_Interrupts ETH DMA Interrupts 
+/** @defgroup ETH_DMA_Interrupts ETH DMA Interrupts
   * @{
-  */ 
-#define ETH_DMA_IT_TST       ((uint32_t)0x20000000U)  /*!< Time-stamp trigger interrupt (on DMA) */
-#define ETH_DMA_IT_PMT       ((uint32_t)0x10000000U)  /*!< PMT interrupt (on DMA) */
-#define ETH_DMA_IT_MMC       ((uint32_t)0x08000000U)  /*!< MMC interrupt (on DMA) */
-#define ETH_DMA_IT_NIS       ((uint32_t)0x00010000U)  /*!< Normal interrupt summary */
-#define ETH_DMA_IT_AIS       ((uint32_t)0x00008000U)  /*!< Abnormal interrupt summary */
-#define ETH_DMA_IT_ER        ((uint32_t)0x00004000U)  /*!< Early receive interrupt */
-#define ETH_DMA_IT_FBE       ((uint32_t)0x00002000U)  /*!< Fatal bus error interrupt */
-#define ETH_DMA_IT_ET        ((uint32_t)0x00000400U)  /*!< Early transmit interrupt */
-#define ETH_DMA_IT_RWT       ((uint32_t)0x00000200U)  /*!< Receive watchdog timeout interrupt */
-#define ETH_DMA_IT_RPS       ((uint32_t)0x00000100U)  /*!< Receive process stopped interrupt */
-#define ETH_DMA_IT_RBU       ((uint32_t)0x00000080U)  /*!< Receive buffer unavailable interrupt */
-#define ETH_DMA_IT_R         ((uint32_t)0x00000040U)  /*!< Receive interrupt */
-#define ETH_DMA_IT_TU        ((uint32_t)0x00000020U)  /*!< Underflow interrupt */
-#define ETH_DMA_IT_RO        ((uint32_t)0x00000010U)  /*!< Overflow interrupt */
-#define ETH_DMA_IT_TJT       ((uint32_t)0x00000008U)  /*!< Transmit jabber timeout interrupt */
-#define ETH_DMA_IT_TBU       ((uint32_t)0x00000004U)  /*!< Transmit buffer unavailable interrupt */
-#define ETH_DMA_IT_TPS       ((uint32_t)0x00000002U)  /*!< Transmit process stopped interrupt */
-#define ETH_DMA_IT_T         ((uint32_t)0x00000001U)  /*!< Transmit interrupt */
+  */
+#define ETH_DMA_IT_TST       0x20000000U  /*!< Time-stamp trigger interrupt (on DMA) */
+#define ETH_DMA_IT_PMT       0x10000000U  /*!< PMT interrupt (on DMA) */
+#define ETH_DMA_IT_MMC       0x08000000U  /*!< MMC interrupt (on DMA) */
+#define ETH_DMA_IT_NIS       0x00010000U  /*!< Normal interrupt summary */
+#define ETH_DMA_IT_AIS       0x00008000U  /*!< Abnormal interrupt summary */
+#define ETH_DMA_IT_ER        0x00004000U  /*!< Early receive interrupt */
+#define ETH_DMA_IT_FBE       0x00002000U  /*!< Fatal bus error interrupt */
+#define ETH_DMA_IT_ET        0x00000400U  /*!< Early transmit interrupt */
+#define ETH_DMA_IT_RWT       0x00000200U  /*!< Receive watchdog timeout interrupt */
+#define ETH_DMA_IT_RPS       0x00000100U  /*!< Receive process stopped interrupt */
+#define ETH_DMA_IT_RBU       0x00000080U  /*!< Receive buffer unavailable interrupt */
+#define ETH_DMA_IT_R         0x00000040U  /*!< Receive interrupt */
+#define ETH_DMA_IT_TU        0x00000020U  /*!< Underflow interrupt */
+#define ETH_DMA_IT_RO        0x00000010U  /*!< Overflow interrupt */
+#define ETH_DMA_IT_TJT       0x00000008U  /*!< Transmit jabber timeout interrupt */
+#define ETH_DMA_IT_TBU       0x00000004U  /*!< Transmit buffer unavailable interrupt */
+#define ETH_DMA_IT_TPS       0x00000002U  /*!< Transmit process stopped interrupt */
+#define ETH_DMA_IT_T         0x00000001U  /*!< Transmit interrupt */
 /**
   * @}
   */
 
-/** @defgroup ETH_DMA_transmit_process_state ETH DMA transmit process state 
+/** @defgroup ETH_DMA_transmit_process_state ETH DMA transmit process state
   * @{
-  */ 
-#define ETH_DMA_TRANSMITPROCESS_STOPPED     ((uint32_t)0x00000000U)  /*!< Stopped - Reset or Stop Tx Command issued */
-#define ETH_DMA_TRANSMITPROCESS_FETCHING    ((uint32_t)0x00100000U)  /*!< Running - fetching the Tx descriptor */
-#define ETH_DMA_TRANSMITPROCESS_WAITING     ((uint32_t)0x00200000U)  /*!< Running - waiting for status */
-#define ETH_DMA_TRANSMITPROCESS_READING     ((uint32_t)0x00300000U)  /*!< Running - reading the data from host memory */
-#define ETH_DMA_TRANSMITPROCESS_SUSPENDED   ((uint32_t)0x00600000U)  /*!< Suspended - Tx Descriptor unavailable */
-#define ETH_DMA_TRANSMITPROCESS_CLOSING     ((uint32_t)0x00700000U)  /*!< Running - closing Rx descriptor */
+  */
+#define ETH_DMA_TRANSMITPROCESS_STOPPED     0x00000000U  /*!< Stopped - Reset or Stop Tx Command issued */
+#define ETH_DMA_TRANSMITPROCESS_FETCHING    0x00100000U  /*!< Running - fetching the Tx descriptor */
+#define ETH_DMA_TRANSMITPROCESS_WAITING     0x00200000U  /*!< Running - waiting for status */
+#define ETH_DMA_TRANSMITPROCESS_READING     0x00300000U  /*!< Running - reading the data from host memory */
+#define ETH_DMA_TRANSMITPROCESS_SUSPENDED   0x00600000U  /*!< Suspended - Tx Descriptor unavailable */
+#define ETH_DMA_TRANSMITPROCESS_CLOSING     0x00700000U  /*!< Running - closing Rx descriptor */
 
 /**
   * @}
-  */ 
+  */
 
 
-/** @defgroup ETH_DMA_receive_process_state ETH DMA receive process state 
+/** @defgroup ETH_DMA_receive_process_state ETH DMA receive process state
   * @{
-  */ 
-#define ETH_DMA_RECEIVEPROCESS_STOPPED      ((uint32_t)0x00000000U)  /*!< Stopped - Reset or Stop Rx Command issued */
-#define ETH_DMA_RECEIVEPROCESS_FETCHING     ((uint32_t)0x00020000U)  /*!< Running - fetching the Rx descriptor */
-#define ETH_DMA_RECEIVEPROCESS_WAITING      ((uint32_t)0x00060000U)  /*!< Running - waiting for packet */
-#define ETH_DMA_RECEIVEPROCESS_SUSPENDED    ((uint32_t)0x00080000U)  /*!< Suspended - Rx Descriptor unavailable */
-#define ETH_DMA_RECEIVEPROCESS_CLOSING      ((uint32_t)0x000A0000U)  /*!< Running - closing descriptor */
-#define ETH_DMA_RECEIVEPROCESS_QUEUING      ((uint32_t)0x000E0000U)  /*!< Running - queuing the receive frame into host memory */
+  */
+#define ETH_DMA_RECEIVEPROCESS_STOPPED      0x00000000U  /*!< Stopped - Reset or Stop Rx Command issued */
+#define ETH_DMA_RECEIVEPROCESS_FETCHING     0x00020000U  /*!< Running - fetching the Rx descriptor */
+#define ETH_DMA_RECEIVEPROCESS_WAITING      0x00060000U  /*!< Running - waiting for packet */
+#define ETH_DMA_RECEIVEPROCESS_SUSPENDED    0x00080000U  /*!< Suspended - Rx Descriptor unavailable */
+#define ETH_DMA_RECEIVEPROCESS_CLOSING      0x000A0000U  /*!< Running - closing descriptor */
+#define ETH_DMA_RECEIVEPROCESS_QUEUING      0x000E0000U  /*!< Running - queuing the receive frame into host memory */
 
 /**
   * @}
@@ -1583,611 +1796,330 @@ typedef  void (*pETH_CallbackTypeDef)(ETH_HandleTypeDef * heth); /*!< pointer to
 
 /** @defgroup ETH_DMA_overflow ETH DMA overflow
   * @{
-  */ 
-#define ETH_DMA_OVERFLOW_RXFIFOCOUNTER      ((uint32_t)0x10000000U)  /*!< Overflow bit for FIFO overflow counter */
-#define ETH_DMA_OVERFLOW_MISSEDFRAMECOUNTER ((uint32_t)0x00010000U)  /*!< Overflow bit for missed frame counter */
-/**
-  * @}
-  */ 
-
-/** @defgroup ETH_EXTI_LINE_WAKEUP ETH EXTI LINE WAKEUP
-  * @{
-  */ 
-#define ETH_EXTI_LINE_WAKEUP              ((uint32_t)0x00080000U)  /*!< External interrupt line 19 Connected to the ETH EXTI Line */
-
+  */
+#define ETH_DMA_OVERFLOW_RXFIFOCOUNTER      0x10000000U  /*!< Overflow bit for FIFO overflow counter */
+#define ETH_DMA_OVERFLOW_MISSEDFRAMECOUNTER 0x00010000U  /*!< Overflow bit for missed frame counter */
 /**
   * @}
   */
-
+/** @defgroup ETH_PTP_Config_Status ETH PTP Config Status
+  * @{
+  */
+#define HAL_ETH_PTP_NOT_CONFIGURATED       ((uint32_t)0x00000000U)    /*!< ETH PTP Configuration not done */
+#define HAL_ETH_PTP_CONFIGURATED           ((uint32_t)0x00000001U)    /*!< ETH PTP Configuration done     */
+/**
+  * @}
+  */
 /**
   * @}
   */
 
 /* Exported macro ------------------------------------------------------------*/
 /** @defgroup ETH_Exported_Macros ETH Exported Macros
- *  @brief macros to handle interrupts and specific clock configurations
- * @{
- */
- 
+  * @{
+  */
+
 /** @brief Reset ETH handle state
-  * @param  __HANDLE__ specifies the ETH handle.
+  * @param  __HANDLE__: specifies the ETH handle.
   * @retval None
   */
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
-#define __HAL_ETH_RESET_HANDLE_STATE(__HANDLE__)  do{                                                 \
-                                                       (__HANDLE__)->State = HAL_ETH_STATE_RESET;     \
-                                                       (__HANDLE__)->MspInitCallback = NULL;          \
-                                                       (__HANDLE__)->MspDeInitCallback = NULL;        \
-                                                     } while(0)
+#define __HAL_ETH_RESET_HANDLE_STATE(__HANDLE__)  do{                                                   \
+                                                      (__HANDLE__)->gState = HAL_ETH_STATE_RESET;      \
+                                                      (__HANDLE__)->MspInitCallback = NULL;             \
+                                                      (__HANDLE__)->MspDeInitCallback = NULL;           \
+                                                    } while(0)
 #else
-#define __HAL_ETH_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_ETH_STATE_RESET)
+#define __HAL_ETH_RESET_HANDLE_STATE(__HANDLE__)  do{                                                   \
+                                                      (__HANDLE__)->gState = HAL_ETH_STATE_RESET;      \
+                                                    } while(0)
 #endif /*USE_HAL_ETH_REGISTER_CALLBACKS */
 
-/** 
-  * @brief  Checks whether the specified Ethernet DMA Tx Desc flag is set or not.
-  * @param  __HANDLE__ ETH Handle
-  * @param  __FLAG__ specifies the flag of TDES0 to check.
-  * @retval the ETH_DMATxDescFlag (SET or RESET).
-  */
-#define __HAL_ETH_DMATXDESC_GET_FLAG(__HANDLE__, __FLAG__)             ((__HANDLE__)->TxDesc->Status & (__FLAG__) == (__FLAG__))
-
 /**
-  * @brief  Checks whether the specified Ethernet DMA Rx Desc flag is set or not.
-  * @param  __HANDLE__ ETH Handle
-  * @param  __FLAG__ specifies the flag of RDES0 to check.
-  * @retval the ETH_DMATxDescFlag (SET or RESET).
-  */
-#define __HAL_ETH_DMARXDESC_GET_FLAG(__HANDLE__, __FLAG__)             ((__HANDLE__)->RxDesc->Status & (__FLAG__) == (__FLAG__))
-
-/**
-  * @brief  Enables the specified DMA Rx Desc receive interrupt.
-  * @param  __HANDLE__ ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_DMARXDESC_ENABLE_IT(__HANDLE__)                          ((__HANDLE__)->RxDesc->ControlBufferSize &=(~(uint32_t)ETH_DMARXDESC_DIC))
-
-/**
-  * @brief  Disables the specified DMA Rx Desc receive interrupt.
-  * @param  __HANDLE__ ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_DMARXDESC_DISABLE_IT(__HANDLE__)                         ((__HANDLE__)->RxDesc->ControlBufferSize |= ETH_DMARXDESC_DIC)
-
-/**
-  * @brief  Set the specified DMA Rx Desc Own bit.
-  * @param  __HANDLE__ ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_DMARXDESC_SET_OWN_BIT(__HANDLE__)                           ((__HANDLE__)->RxDesc->Status |= ETH_DMARXDESC_OWN)
-
-/**
-  * @brief  Returns the specified Ethernet DMA Tx Desc collision count.
-  * @param  __HANDLE__ ETH Handle                     
-  * @retval The Transmit descriptor collision counter value.
-  */
-#define __HAL_ETH_DMATXDESC_GET_COLLISION_COUNT(__HANDLE__)                   (((__HANDLE__)->TxDesc->Status & ETH_DMATXDESC_CC) >> ETH_DMATXDESC_COLLISION_COUNTSHIFT)
-
-/**
-  * @brief  Set the specified DMA Tx Desc Own bit.
-  * @param  __HANDLE__ ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_DMATXDESC_SET_OWN_BIT(__HANDLE__)                       ((__HANDLE__)->TxDesc->Status |= ETH_DMATXDESC_OWN)
-
-/**
-  * @brief  Enables the specified DMA Tx Desc Transmit interrupt.
-  * @param  __HANDLE__ ETH Handle                   
-  * @retval None
-  */
-#define __HAL_ETH_DMATXDESC_ENABLE_IT(__HANDLE__)                          ((__HANDLE__)->TxDesc->Status |= ETH_DMATXDESC_IC)
-
-/**
-  * @brief  Disables the specified DMA Tx Desc Transmit interrupt.
-  * @param  __HANDLE__ ETH Handle             
-  * @retval None
-  */
-#define __HAL_ETH_DMATXDESC_DISABLE_IT(__HANDLE__)                          ((__HANDLE__)->TxDesc->Status &= ~ETH_DMATXDESC_IC)
-
-/**
-  * @brief  Selects the specified Ethernet DMA Tx Desc Checksum Insertion.
-  * @param  __HANDLE__ ETH Handle  
-  * @param  __CHECKSUM__ specifies is the DMA Tx desc checksum insertion.
-  *   This parameter can be one of the following values:
-  *     @arg ETH_DMATXDESC_CHECKSUMBYPASS : Checksum bypass
-  *     @arg ETH_DMATXDESC_CHECKSUMIPV4HEADER : IPv4 header checksum
-  *     @arg ETH_DMATXDESC_CHECKSUMTCPUDPICMPSEGMENT : TCP/UDP/ICMP checksum. Pseudo header checksum is assumed to be present
-  *     @arg ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL : TCP/UDP/ICMP checksum fully in hardware including pseudo header                                                                
-  * @retval None
-  */
-#define __HAL_ETH_DMATXDESC_CHECKSUM_INSERTION(__HANDLE__, __CHECKSUM__)     ((__HANDLE__)->TxDesc->Status |= (__CHECKSUM__))
-
-/**
-  * @brief  Enables the DMA Tx Desc CRC.
-  * @param  __HANDLE__ ETH Handle 
-  * @retval None
-  */
-#define __HAL_ETH_DMATXDESC_CRC_ENABLE(__HANDLE__)                          ((__HANDLE__)->TxDesc->Status &= ~ETH_DMATXDESC_DC)
-
-/**
-  * @brief  Disables the DMA Tx Desc CRC.
-  * @param  __HANDLE__ ETH Handle 
-  * @retval None
-  */
-#define __HAL_ETH_DMATXDESC_CRC_DISABLE(__HANDLE__)                         ((__HANDLE__)->TxDesc->Status |= ETH_DMATXDESC_DC)
-
-/**
-  * @brief  Enables the DMA Tx Desc padding for frame shorter than 64 bytes.
-  * @param  __HANDLE__ ETH Handle 
-  * @retval None
-  */
-#define __HAL_ETH_DMATXDESC_SHORT_FRAME_PADDING_ENABLE(__HANDLE__)            ((__HANDLE__)->TxDesc->Status &= ~ETH_DMATXDESC_DP)
-
-/**
-  * @brief  Disables the DMA Tx Desc padding for frame shorter than 64 bytes.
-  * @param  __HANDLE__ ETH Handle 
-  * @retval None
-  */
-#define __HAL_ETH_DMATXDESC_SHORT_FRAME_PADDING_DISABLE(__HANDLE__)           ((__HANDLE__)->TxDesc->Status |= ETH_DMATXDESC_DP)
-
-/** 
- * @brief  Enables the specified Ethernet MAC interrupts.
-  * @param  __HANDLE__    ETH Handle
-  * @param  __INTERRUPT__ specifies the Ethernet MAC interrupt sources to be
-  *   enabled or disabled.
-  *   This parameter can be any combination of the following values:
-  *     @arg ETH_MAC_IT_TST : Time stamp trigger interrupt 
-  *     @arg ETH_MAC_IT_PMT : PMT interrupt 
-  * @retval None
-  */
-#define __HAL_ETH_MAC_ENABLE_IT(__HANDLE__, __INTERRUPT__)                 ((__HANDLE__)->Instance->MACIMR |= (__INTERRUPT__))
-
-/**
-  * @brief  Disables the specified Ethernet MAC interrupts.
-  * @param  __HANDLE__    ETH Handle
-  * @param  __INTERRUPT__ specifies the Ethernet MAC interrupt sources to be
-  *   enabled or disabled.
-  *   This parameter can be any combination of the following values:
-  *     @arg ETH_MAC_IT_TST : Time stamp trigger interrupt 
-  *     @arg ETH_MAC_IT_PMT : PMT interrupt
-  * @retval None
-  */
-#define __HAL_ETH_MAC_DISABLE_IT(__HANDLE__, __INTERRUPT__)                ((__HANDLE__)->Instance->MACIMR &= ~(__INTERRUPT__))
-
-/**
-  * @brief  Initiate a Pause Control Frame (Full-duplex only).
-  * @param  __HANDLE__ ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_INITIATE_PAUSE_CONTROL_FRAME(__HANDLE__)              ((__HANDLE__)->Instance->MACFCR |= ETH_MACFCR_FCBBPA)
-
-/**
-  * @brief  Checks whether the Ethernet flow control busy bit is set or not.
-  * @param  __HANDLE__ ETH Handle
-  * @retval The new state of flow control busy status bit (SET or RESET).
-  */
-#define __HAL_ETH_GET_FLOW_CONTROL_BUSY_STATUS(__HANDLE__)               (((__HANDLE__)->Instance->MACFCR & ETH_MACFCR_FCBBPA) == ETH_MACFCR_FCBBPA)
-
-/**
-  * @brief  Enables the MAC Back Pressure operation activation (Half-duplex only).
-  * @param  __HANDLE__ ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_BACK_PRESSURE_ACTIVATION_ENABLE(__HANDLE__)          ((__HANDLE__)->Instance->MACFCR |= ETH_MACFCR_FCBBPA)
-
-/**
-  * @brief  Disables the MAC BackPressure operation activation (Half-duplex only).
-  * @param  __HANDLE__ ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_BACK_PRESSURE_ACTIVATION_DISABLE(__HANDLE__)         ((__HANDLE__)->Instance->MACFCR &= ~ETH_MACFCR_FCBBPA)
-
-/**
-  * @brief  Checks whether the specified Ethernet MAC flag is set or not.
-  * @param  __HANDLE__ ETH Handle
-  * @param  __FLAG__ specifies the flag to check.
-  *   This parameter can be one of the following values:
-  *     @arg ETH_MAC_FLAG_TST  : Time stamp trigger flag   
-  *     @arg ETH_MAC_FLAG_MMCT : MMC transmit flag  
-  *     @arg ETH_MAC_FLAG_MMCR : MMC receive flag   
-  *     @arg ETH_MAC_FLAG_MMC  : MMC flag  
-  *     @arg ETH_MAC_FLAG_PMT  : PMT flag  
-  * @retval The state of Ethernet MAC flag.
-  */
-#define __HAL_ETH_MAC_GET_FLAG(__HANDLE__, __FLAG__)                   (((__HANDLE__)->Instance->MACSR &( __FLAG__)) == ( __FLAG__))
-
-/** 
-  * @brief  Enables the specified Ethernet DMA interrupts.
-  * @param  __HANDLE__    ETH Handle
-  * @param  __INTERRUPT__ specifies the Ethernet DMA interrupt sources to be
+  * @brief  Enables the specified ETHERNET DMA interrupts.
+  * @param  __HANDLE__   : ETH Handle
+  * @param  __INTERRUPT__: specifies the ETHERNET DMA interrupt sources to be
   *   enabled @ref ETH_DMA_Interrupts
   * @retval None
   */
-#define __HAL_ETH_DMA_ENABLE_IT(__HANDLE__, __INTERRUPT__)                 ((__HANDLE__)->Instance->DMAIER |= (__INTERRUPT__))
+#define __HAL_ETH_DMA_ENABLE_IT(__HANDLE__, __INTERRUPT__)                 ((__HANDLE__)->Instance->DMAIER \
+                                                                            |= (__INTERRUPT__))
 
 /**
-  * @brief  Disables the specified Ethernet DMA interrupts.
-  * @param  __HANDLE__    ETH Handle
-  * @param  __INTERRUPT__ specifies the Ethernet DMA interrupt sources to be
+  * @brief  Disables the specified ETHERNET DMA interrupts.
+  * @param  __HANDLE__   : ETH Handle
+  * @param  __INTERRUPT__: specifies the ETHERNET DMA interrupt sources to be
   *   disabled. @ref ETH_DMA_Interrupts
   * @retval None
   */
-#define __HAL_ETH_DMA_DISABLE_IT(__HANDLE__, __INTERRUPT__)                ((__HANDLE__)->Instance->DMAIER &= ~(__INTERRUPT__))
+#define __HAL_ETH_DMA_DISABLE_IT(__HANDLE__, __INTERRUPT__)                ((__HANDLE__)->Instance->DMAIER \
+                                                                            &= ~(__INTERRUPT__))
 
 /**
-  * @brief  Clears the Ethernet DMA IT pending bit.
-  * @param  __HANDLE__    ETH Handle
-  * @param  __INTERRUPT__ specifies the interrupt pending bit to clear. @ref ETH_DMA_Interrupts
+  * @brief  Gets the ETHERNET DMA IT source enabled or disabled.
+  * @param  __HANDLE__   : ETH Handle
+  * @param  __INTERRUPT__: specifies the interrupt source to get . @ref ETH_DMA_Interrupts
+  * @retval The ETH DMA IT Source enabled or disabled
+  */
+#define __HAL_ETH_DMA_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)      (((__HANDLE__)->Instance->DMAIER &\
+                                                                      (__INTERRUPT__)) == (__INTERRUPT__))
+
+/**
+  * @brief  Gets the ETHERNET DMA IT pending bit.
+  * @param  __HANDLE__   : ETH Handle
+  * @param  __INTERRUPT__: specifies the interrupt source to get . @ref ETH_DMA_Interrupts
+  * @retval The state of ETH DMA IT (SET or RESET)
+  */
+#define __HAL_ETH_DMA_GET_IT(__HANDLE__, __INTERRUPT__)      (((__HANDLE__)->Instance->DMASR &\
+                                                               (__INTERRUPT__)) == (__INTERRUPT__))
+
+/**
+  * @brief  Clears the ETHERNET DMA IT pending bit.
+  * @param  __HANDLE__   : ETH Handle
+  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear. @ref ETH_DMA_Interrupts
   * @retval None
   */
-#define __HAL_ETH_DMA_CLEAR_IT(__HANDLE__, __INTERRUPT__)      ((__HANDLE__)->Instance->DMASR =(__INTERRUPT__))
+#define __HAL_ETH_DMA_CLEAR_IT(__HANDLE__, __INTERRUPT__)      ((__HANDLE__)->Instance->DMASR = (__INTERRUPT__))
 
 /**
-  * @brief  Checks whether the specified Ethernet DMA flag is set or not.
-* @param  __HANDLE__ ETH Handle
-  * @param  __FLAG__ specifies the flag to check. @ref ETH_DMA_Flags
-  * @retval The new state of ETH_DMA_FLAG (SET or RESET).
+  * @brief  Checks whether the specified ETHERNET DMA flag is set or not.
+  * @param  __HANDLE__: ETH Handle
+  * @param  __FLAG__: specifies the flag to check. @ref ETH_DMA_Status_Flags
+  * @retval The state of ETH DMA FLAG (SET or RESET).
   */
-#define __HAL_ETH_DMA_GET_FLAG(__HANDLE__, __FLAG__)                   (((__HANDLE__)->Instance->DMASR &( __FLAG__)) == ( __FLAG__))
+#define __HAL_ETH_DMA_GET_FLAG(__HANDLE__, __FLAG__)                   (((__HANDLE__)->Instance->DMACSR &\
+                                                                         ( __FLAG__)) == ( __FLAG__))
 
 /**
-  * @brief  Checks whether the specified Ethernet DMA flag is set or not.
-  * @param  __HANDLE__ ETH Handle
-  * @param  __FLAG__ specifies the flag to clear. @ref ETH_DMA_Flags
-  * @retval The new state of ETH_DMA_FLAG (SET or RESET).
+  * @brief  Clears the specified ETHERNET DMA flag.
+  * @param  __HANDLE__: ETH Handle
+  * @param  __FLAG__: specifies the flag to check. @ref ETH_DMA_Status_Flags
+  * @retval The state of ETH DMA FLAG (SET or RESET).
   */
-#define __HAL_ETH_DMA_CLEAR_FLAG(__HANDLE__, __FLAG__)                 ((__HANDLE__)->Instance->DMASR = (__FLAG__))
+#define __HAL_ETH_DMA_CLEAR_FLAG(__HANDLE__, __FLAG__)                   ((__HANDLE__)->Instance->DMACSR = ( __FLAG__))
 
 /**
-  * @brief  Checks whether the specified Ethernet DMA overflow flag is set or not.
-  * @param  __HANDLE__ ETH Handle
-  * @param  __OVERFLOW__ specifies the DMA overflow flag to check.
-  *   This parameter can be one of the following values:
-  *     @arg ETH_DMA_OVERFLOW_RXFIFOCOUNTER : Overflow for FIFO Overflows Counter
-  *     @arg ETH_DMA_OVERFLOW_MISSEDFRAMECOUNTER : Overflow for Buffer Unavailable Missed Frame Counter
-  * @retval The state of Ethernet DMA overflow Flag (SET or RESET).
-  */
-#define __HAL_ETH_GET_DMA_OVERFLOW_STATUS(__HANDLE__, __OVERFLOW__)       (((__HANDLE__)->Instance->DMAMFBOCR & (__OVERFLOW__)) == (__OVERFLOW__))
-
-/**
-  * @brief  Set the DMA Receive status watchdog timer register value
-  * @param  __HANDLE__ ETH Handle
-  * @param  __VALUE__ DMA Receive status watchdog timer register value   
+  * @brief  Enables the specified ETHERNET MAC interrupts.
+  * @param  __HANDLE__   : ETH Handle
+  * @param  __INTERRUPT__: specifies the ETHERNET MAC interrupt sources to be
+  *   enabled @ref ETH_MAC_Interrupts
   * @retval None
   */
-#define __HAL_ETH_SET_RECEIVE_WATCHDOG_TIMER(__HANDLE__, __VALUE__)       ((__HANDLE__)->Instance->DMARSWTR = (__VALUE__))
-
-/** 
-  * @brief  Enables any unicast packet filtered by the MAC address
-  *   recognition to be a wake-up frame.
-  * @param  __HANDLE__ ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_GLOBAL_UNICAST_WAKEUP_ENABLE(__HANDLE__)               ((__HANDLE__)->Instance->MACPMTCSR |= ETH_MACPMTCSR_GU)
+#define __HAL_ETH_MAC_ENABLE_IT(__HANDLE__, __INTERRUPT__)                 ((__HANDLE__)->Instance->MACIER \
+                                                                            |= (__INTERRUPT__))
 
 /**
-  * @brief  Disables any unicast packet filtered by the MAC address
-  *   recognition to be a wake-up frame.
-  * @param  __HANDLE__ ETH Handle.
+  * @brief  Disables the specified ETHERNET MAC interrupts.
+  * @param  __HANDLE__   : ETH Handle
+  * @param  __INTERRUPT__: specifies the ETHERNET MAC interrupt sources to be
+  *   enabled @ref ETH_MAC_Interrupts
   * @retval None
   */
-#define __HAL_ETH_GLOBAL_UNICAST_WAKEUP_DISABLE(__HANDLE__)              ((__HANDLE__)->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_GU)
+#define __HAL_ETH_MAC_DISABLE_IT(__HANDLE__, __INTERRUPT__)                 ((__HANDLE__)->Instance->MACIER \
+                                                                             &= ~(__INTERRUPT__))
 
 /**
-  * @brief  Enables the MAC Wake-Up Frame Detection.
-  * @param  __HANDLE__ ETH Handle.
-  * @retval None
+  * @brief  Checks whether the specified ETHERNET MAC flag is set or not.
+  * @param  __HANDLE__: ETH Handle
+  * @param  __INTERRUPT__: specifies the flag to check. @ref ETH_MAC_Interrupts
+  * @retval The state of ETH MAC IT (SET or RESET).
   */
-#define __HAL_ETH_WAKEUP_FRAME_DETECTION_ENABLE(__HANDLE__)              ((__HANDLE__)->Instance->MACPMTCSR |= ETH_MACPMTCSR_WFE)
+#define __HAL_ETH_MAC_GET_IT(__HANDLE__, __INTERRUPT__)                   (((__HANDLE__)->Instance->MACSR &\
+                                                                            ( __INTERRUPT__)) == ( __INTERRUPT__))
+
+/*!< External interrupt line 19 Connected to the ETH wakeup EXTI Line */
+#define ETH_WAKEUP_EXTI_LINE  ((uint32_t)0x00080000U)
 
 /**
-  * @brief  Disables the MAC Wake-Up Frame Detection.
-  * @param  __HANDLE__ ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_WAKEUP_FRAME_DETECTION_DISABLE(__HANDLE__)             ((__HANDLE__)->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_WFE)
-
-/**
-  * @brief  Enables the MAC Magic Packet Detection.
-  * @param  __HANDLE__ ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_MAGIC_PACKET_DETECTION_ENABLE(__HANDLE__)              ((__HANDLE__)->Instance->MACPMTCSR |= ETH_MACPMTCSR_MPE)
-
-/**
-  * @brief  Disables the MAC Magic Packet Detection.
-  * @param  __HANDLE__ ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_MAGIC_PACKET_DETECTION_DISABLE(__HANDLE__)             ((__HANDLE__)->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_WFE)
-
-/**
-  * @brief  Enables the MAC Power Down.
-  * @param  __HANDLE__ ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_POWER_DOWN_ENABLE(__HANDLE__)                         ((__HANDLE__)->Instance->MACPMTCSR |= ETH_MACPMTCSR_PD)
-
-/**
-  * @brief  Disables the MAC Power Down.
-  * @param  __HANDLE__ ETH Handle
-  * @retval None
-  */
-#define __HAL_ETH_POWER_DOWN_DISABLE(__HANDLE__)                        ((__HANDLE__)->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_PD)
-
-/**
-  * @brief  Checks whether the specified Ethernet PMT flag is set or not.
-  * @param  __HANDLE__ ETH Handle.
-  * @param  __FLAG__ specifies the flag to check.
-  *   This parameter can be one of the following values:
-  *     @arg ETH_PMT_FLAG_WUFFRPR : Wake-Up Frame Filter Register Pointer Reset 
-  *     @arg ETH_PMT_FLAG_WUFR    : Wake-Up Frame Received 
-  *     @arg ETH_PMT_FLAG_MPR     : Magic Packet Received
-  * @retval The new state of Ethernet PMT Flag (SET or RESET).
-  */
-#define __HAL_ETH_GET_PMT_FLAG_STATUS(__HANDLE__, __FLAG__)               (((__HANDLE__)->Instance->MACPMTCSR &( __FLAG__)) == ( __FLAG__))
-
-/** 
-  * @brief  Preset and Initialize the MMC counters to almost-full value: 0xFFFF_FFF0 (full - 16)
-  * @param   __HANDLE__ ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_MMC_COUNTER_FULL_PRESET(__HANDLE__)                     ((__HANDLE__)->Instance->MMCCR |= (ETH_MMCCR_MCFHP | ETH_MMCCR_MCP))
-
-/**
-  * @brief  Preset and Initialize the MMC counters to almost-half value: 0x7FFF_FFF0 (half - 16)
-  * @param  __HANDLE__ ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_MMC_COUNTER_HALF_PRESET(__HANDLE__)                     do{(__HANDLE__)->Instance->MMCCR &= ~ETH_MMCCR_MCFHP;\
-                                                                          (__HANDLE__)->Instance->MMCCR |= ETH_MMCCR_MCP;} while (0)
-
-/**
-  * @brief  Enables the MMC Counter Freeze.
-  * @param  __HANDLE__ ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_MMC_COUNTER_FREEZE_ENABLE(__HANDLE__)                  ((__HANDLE__)->Instance->MMCCR |= ETH_MMCCR_MCF)
-
-/**
-  * @brief  Disables the MMC Counter Freeze.
-  * @param  __HANDLE__ ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_MMC_COUNTER_FREEZE_DISABLE(__HANDLE__)                 ((__HANDLE__)->Instance->MMCCR &= ~ETH_MMCCR_MCF)
-
-/**
-  * @brief  Enables the MMC Reset On Read.
-  * @param  __HANDLE__ ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_ETH_MMC_RESET_ONREAD_ENABLE(__HANDLE__)                ((__HANDLE__)->Instance->MMCCR |= ETH_MMCCR_ROR)
-
-/**
-  * @brief  Disables the MMC Reset On Read.
-  * @param  __HANDLE__ ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_ETH_MMC_RESET_ONREAD_DISABLE(__HANDLE__)               ((__HANDLE__)->Instance->MMCCR &= ~ETH_MMCCR_ROR)
-
-/**
-  * @brief  Enables the MMC Counter Stop Rollover.
-  * @param  __HANDLE__ ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_ETH_MMC_COUNTER_ROLLOVER_ENABLE(__HANDLE__)            ((__HANDLE__)->Instance->MMCCR &= ~ETH_MMCCR_CSR)
-
-/**
-  * @brief  Disables the MMC Counter Stop Rollover.
-  * @param  __HANDLE__ ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_ETH_MMC_COUNTER_ROLLOVER_DISABLE(__HANDLE__)           ((__HANDLE__)->Instance->MMCCR |= ETH_MMCCR_CSR)
-
-/**
-  * @brief  Resets the MMC Counters.
-  * @param   __HANDLE__ ETH Handle.
-  * @retval None
-  */
-#define __HAL_ETH_MMC_COUNTERS_RESET(__HANDLE__)                         ((__HANDLE__)->Instance->MMCCR |= ETH_MMCCR_CR)
-
-/**
-  * @brief  Enables the specified Ethernet MMC Rx interrupts.
-  * @param   __HANDLE__ ETH Handle.
-  * @param  __INTERRUPT__ specifies the Ethernet MMC interrupt sources to be enabled or disabled.
-  *   This parameter can be one of the following values:  
-  *     @arg ETH_MMC_IT_RGUF  : When Rx good unicast frames counter reaches half the maximum value 
-  *     @arg ETH_MMC_IT_RFAE  : When Rx alignment error counter reaches half the maximum value 
-  *     @arg ETH_MMC_IT_RFCE  : When Rx crc error counter reaches half the maximum value
-  * @retval None
-  */
-#define __HAL_ETH_MMC_RX_IT_ENABLE(__HANDLE__, __INTERRUPT__)               (__HANDLE__)->Instance->MMCRIMR &= ~((__INTERRUPT__) & 0xEFFFFFFF)
-/**
-  * @brief  Disables the specified Ethernet MMC Rx interrupts.
-  * @param   __HANDLE__ ETH Handle.
-  * @param  __INTERRUPT__ specifies the Ethernet MMC interrupt sources to be enabled or disabled.
-  *   This parameter can be one of the following values: 
-  *     @arg ETH_MMC_IT_RGUF  : When Rx good unicast frames counter reaches half the maximum value 
-  *     @arg ETH_MMC_IT_RFAE  : When Rx alignment error counter reaches half the maximum value 
-  *     @arg ETH_MMC_IT_RFCE  : When Rx crc error counter reaches half the maximum value
-  * @retval None
-  */
-#define __HAL_ETH_MMC_RX_IT_DISABLE(__HANDLE__, __INTERRUPT__)              (__HANDLE__)->Instance->MMCRIMR |= ((__INTERRUPT__) & 0xEFFFFFFF)
-/**
-  * @brief  Enables the specified Ethernet MMC Tx interrupts.
-  * @param   __HANDLE__ ETH Handle.
-  * @param  __INTERRUPT__ specifies the Ethernet MMC interrupt sources to be enabled or disabled.
-  *   This parameter can be one of the following values:  
-  *     @arg ETH_MMC_IT_TGF   : When Tx good frame counter reaches half the maximum value 
-  *     @arg ETH_MMC_IT_TGFMSC: When Tx good multi col counter reaches half the maximum value 
-  *     @arg ETH_MMC_IT_TGFSC : When Tx good single col counter reaches half the maximum value 
-  * @retval None
-  */
-#define __HAL_ETH_MMC_TX_IT_ENABLE(__HANDLE__, __INTERRUPT__)            ((__HANDLE__)->Instance->MMCRIMR &= ~ (__INTERRUPT__))
-
-/**
-  * @brief  Disables the specified Ethernet MMC Tx interrupts.
-  * @param   __HANDLE__ ETH Handle.
-  * @param  __INTERRUPT__ specifies the Ethernet MMC interrupt sources to be enabled or disabled.
-  *   This parameter can be one of the following values:  
-  *     @arg ETH_MMC_IT_TGF   : When Tx good frame counter reaches half the maximum value 
-  *     @arg ETH_MMC_IT_TGFMSC: When Tx good multi col counter reaches half the maximum value 
-  *     @arg ETH_MMC_IT_TGFSC : When Tx good single col counter reaches half the maximum value 
-  * @retval None
-  */
-#define __HAL_ETH_MMC_TX_IT_DISABLE(__HANDLE__, __INTERRUPT__)           ((__HANDLE__)->Instance->MMCRIMR |= (__INTERRUPT__))
-
-/**
-  * @brief  Enables the ETH External interrupt line.
-  * @retval None
-  */
-#define __HAL_ETH_WAKEUP_EXTI_ENABLE_IT()    EXTI->IMR |= (ETH_EXTI_LINE_WAKEUP)
-
-/**
-  * @brief  Disables the ETH External interrupt line.
-  * @retval None
-  */
-#define __HAL_ETH_WAKEUP_EXTI_DISABLE_IT()   EXTI->IMR &= ~(ETH_EXTI_LINE_WAKEUP)
-
-/**
-  * @brief Enable event on ETH External event line.
+  * @brief Enable the ETH WAKEUP Exti Line.
+  * @param  __EXTI_LINE__: specifies the ETH WAKEUP Exti sources to be enabled.
+  *   @arg ETH_WAKEUP_EXTI_LINE
   * @retval None.
   */
-#define __HAL_ETH_WAKEUP_EXTI_ENABLE_EVENT()  EXTI->EMR |= (ETH_EXTI_LINE_WAKEUP)
+#define __HAL_ETH_WAKEUP_EXTI_ENABLE_IT(__EXTI_LINE__)   (EXTI->IMR |= (__EXTI_LINE__))
 
 /**
-  * @brief Disable event on ETH External event line
+  * @brief checks whether the specified ETH WAKEUP Exti interrupt flag is set or not.
+  * @param  __EXTI_LINE__: specifies the ETH WAKEUP Exti sources to be cleared.
+  *   @arg ETH_WAKEUP_EXTI_LINE
+  * @retval EXTI ETH WAKEUP Line Status.
+  */
+#define __HAL_ETH_WAKEUP_EXTI_GET_FLAG(__EXTI_LINE__)  (EXTI->PR & (__EXTI_LINE__))
+
+/**
+  * @brief Clear the ETH WAKEUP Exti flag.
+  * @param  __EXTI_LINE__: specifies the ETH WAKEUP Exti sources to be cleared.
+  *   @arg ETH_WAKEUP_EXTI_LINE
   * @retval None.
   */
-#define __HAL_ETH_WAKEUP_EXTI_DISABLE_EVENT() EXTI->EMR &= ~(ETH_EXTI_LINE_WAKEUP)
+#define __HAL_ETH_WAKEUP_EXTI_CLEAR_FLAG(__EXTI_LINE__) (EXTI->PR = (__EXTI_LINE__))
+
 
 /**
-  * @brief  Get flag of the ETH External interrupt line.
+  * @brief  enable rising edge interrupt on selected EXTI line.
+  * @param  __EXTI_LINE__: specifies the ETH WAKEUP EXTI sources to be disabled.
+  *  @arg ETH_WAKEUP_EXTI_LINE
   * @retval None
   */
-#define __HAL_ETH_WAKEUP_EXTI_GET_FLAG()     EXTI->PR & (ETH_EXTI_LINE_WAKEUP)
+#define __HAL_ETH_WAKEUP_EXTI_ENABLE_RISING_EDGE(__EXTI_LINE__) (EXTI->FTSR &= ~(__EXTI_LINE__)); \
+  (EXTI->RTSR |= (__EXTI_LINE__))
 
 /**
-  * @brief  Clear flag of the ETH External interrupt line.
+  * @brief  enable falling edge interrupt on selected EXTI line.
+  * @param  __EXTI_LINE__: specifies the ETH WAKEUP EXTI sources to be disabled.
+  *  @arg ETH_WAKEUP_EXTI_LINE
   * @retval None
   */
-#define __HAL_ETH_WAKEUP_EXTI_CLEAR_FLAG()   EXTI->PR = (ETH_EXTI_LINE_WAKEUP)
+#define __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLING_EDGE(__EXTI_LINE__) (EXTI->RTSR &= ~(__EXTI_LINE__));\
+  (EXTI->FTSR |= (__EXTI_LINE__))
 
 /**
-  * @brief  Enables rising edge trigger to the ETH External interrupt line.
+  * @brief  enable falling edge interrupt on selected EXTI line.
+  * @param  __EXTI_LINE__: specifies the ETH WAKEUP EXTI sources to be disabled.
+  *  @arg ETH_WAKEUP_EXTI_LINE
   * @retval None
   */
-#define __HAL_ETH_WAKEUP_EXTI_ENABLE_RISING_EDGE_TRIGGER()  EXTI->RTSR |= ETH_EXTI_LINE_WAKEUP
-                                                            
+#define __HAL_ETH_WAKEUP_EXTI_ENABLE_RISING_FALLING_EDGE(__EXTI_LINE__) (EXTI->RTSR |= (__EXTI_LINE__));\
+  (EXTI->FTSR |= (__EXTI_LINE__))
+
 /**
-  * @brief  Disables the rising edge trigger to the ETH External interrupt line.
+  * @brief  Generates a Software interrupt on selected EXTI line.
+  * @param  __EXTI_LINE__: specifies the ETH WAKEUP EXTI sources to be disabled.
+  *  @arg ETH_WAKEUP_EXTI_LINE
   * @retval None
   */
-#define __HAL_ETH_WAKEUP_EXTI_DISABLE_RISING_EDGE_TRIGGER()  EXTI->RTSR &= ~(ETH_EXTI_LINE_WAKEUP)                                                          
+#define __HAL_ETH_WAKEUP_EXTI_GENERATE_SWIT(__EXTI_LINE__) (EXTI->SWIER |= (__EXTI_LINE__))
 
-/**
-  * @brief  Enables falling edge trigger to the ETH External interrupt line.
-  * @retval None
-  */                                                      
-#define __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLING_EDGE_TRIGGER()  EXTI->FTSR |= (ETH_EXTI_LINE_WAKEUP)
+#define __HAL_ETH_GET_PTP_CONTROL(__HANDLE__, __FLAG__) (((((__HANDLE__)->Instance->PTPTSCR) & \
+                                                           (__FLAG__)) == (__FLAG__)) ? SET : RESET)
 
-/**
-  * @brief  Disables falling edge trigger to the ETH External interrupt line.
-  * @retval None
-  */
-#define __HAL_ETH_WAKEUP_EXTI_DISABLE_FALLING_EDGE_TRIGGER()  EXTI->FTSR &= ~(ETH_EXTI_LINE_WAKEUP)
-
-/**
-  * @brief  Enables rising/falling edge trigger to the ETH External interrupt line.
-  * @retval None
-  */
-#define __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLINGRISING_TRIGGER()  do{EXTI->RTSR |= ETH_EXTI_LINE_WAKEUP;\
-                                                                 EXTI->FTSR |= ETH_EXTI_LINE_WAKEUP;\
-                                                                 }while(0)
-
-/**
-  * @brief  Disables rising/falling edge trigger to the ETH External interrupt line.
-  * @retval None
-  */
-#define __HAL_ETH_WAKEUP_EXTI_DISABLE_FALLINGRISING_TRIGGER()  do{EXTI->RTSR &= ~(ETH_EXTI_LINE_WAKEUP);\
-                                                                  EXTI->FTSR &= ~(ETH_EXTI_LINE_WAKEUP);\
-                                                                  }while(0)
-
-/**
-  * @brief Generate a Software interrupt on selected EXTI line.
-  * @retval None.
-  */
-#define __HAL_ETH_WAKEUP_EXTI_GENERATE_SWIT()                  EXTI->SWIER|= ETH_EXTI_LINE_WAKEUP
-
+#define __HAL_ETH_SET_PTP_CONTROL(__HANDLE__, __FLAG__)   ((__HANDLE__)->Instance->PTPTSCR |= (__FLAG__))
 /**
   * @}
   */
+
+
 /* Exported functions --------------------------------------------------------*/
 
 /** @addtogroup ETH_Exported_Functions
   * @{
   */
 
-/* Initialization and de-initialization functions  ****************************/
-
 /** @addtogroup ETH_Exported_Functions_Group1
   * @{
   */
+/* Initialization and de initialization functions  **********************************/
 HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth);
 HAL_StatusTypeDef HAL_ETH_DeInit(ETH_HandleTypeDef *heth);
-void HAL_ETH_MspInit(ETH_HandleTypeDef *heth);
-void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth);
-HAL_StatusTypeDef HAL_ETH_DMATxDescListInit(ETH_HandleTypeDef *heth, ETH_DMADescTypeDef *DMATxDescTab, uint8_t* TxBuff, uint32_t TxBuffCount);
-HAL_StatusTypeDef HAL_ETH_DMARxDescListInit(ETH_HandleTypeDef *heth, ETH_DMADescTypeDef *DMARxDescTab, uint8_t *RxBuff, uint32_t RxBuffCount);
+void              HAL_ETH_MspInit(ETH_HandleTypeDef *heth);
+void              HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth);
+
 /* Callbacks Register/UnRegister functions  ***********************************/
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
-HAL_StatusTypeDef HAL_ETH_RegisterCallback(ETH_HandleTypeDef *heth, HAL_ETH_CallbackIDTypeDef CallbackID, pETH_CallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_ETH_RegisterCallback(ETH_HandleTypeDef *heth, HAL_ETH_CallbackIDTypeDef CallbackID,
+                                           pETH_CallbackTypeDef pCallback);
 HAL_StatusTypeDef HAL_ETH_UnRegisterCallback(ETH_HandleTypeDef *heth, HAL_ETH_CallbackIDTypeDef CallbackID);
 #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
 
 /**
   * @}
   */
-/* IO operation functions  ****************************************************/
 
 /** @addtogroup ETH_Exported_Functions_Group2
   * @{
   */
-HAL_StatusTypeDef HAL_ETH_TransmitFrame(ETH_HandleTypeDef *heth, uint32_t FrameLength);
-HAL_StatusTypeDef HAL_ETH_GetReceivedFrame(ETH_HandleTypeDef *heth);
-/* Communication with PHY functions*/
-HAL_StatusTypeDef HAL_ETH_ReadPHYRegister(ETH_HandleTypeDef *heth, uint16_t PHYReg, uint32_t *RegValue);
-HAL_StatusTypeDef HAL_ETH_WritePHYRegister(ETH_HandleTypeDef *heth, uint16_t PHYReg, uint32_t RegValue);
-/* Non-Blocking mode: Interrupt */
-HAL_StatusTypeDef HAL_ETH_GetReceivedFrame_IT(ETH_HandleTypeDef *heth);
-void HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth);
-/* Callback in non blocking modes (Interrupt) */
-void HAL_ETH_TxCpltCallback(ETH_HandleTypeDef *heth);
-void HAL_ETH_RxCpltCallback(ETH_HandleTypeDef *heth);
-void HAL_ETH_ErrorCallback(ETH_HandleTypeDef *heth);
+/* IO operation functions *******************************************************/
+HAL_StatusTypeDef HAL_ETH_Start(ETH_HandleTypeDef *heth);
+HAL_StatusTypeDef HAL_ETH_Start_IT(ETH_HandleTypeDef *heth);
+HAL_StatusTypeDef HAL_ETH_Stop(ETH_HandleTypeDef *heth);
+HAL_StatusTypeDef HAL_ETH_Stop_IT(ETH_HandleTypeDef *heth);
+
+HAL_StatusTypeDef HAL_ETH_ReadData(ETH_HandleTypeDef *heth, void **pAppBuff);
+HAL_StatusTypeDef HAL_ETH_RegisterRxAllocateCallback(ETH_HandleTypeDef *heth,
+                                                     pETH_rxAllocateCallbackTypeDef rxAllocateCallback);
+HAL_StatusTypeDef HAL_ETH_UnRegisterRxAllocateCallback(ETH_HandleTypeDef *heth);
+HAL_StatusTypeDef HAL_ETH_RegisterRxLinkCallback(ETH_HandleTypeDef *heth, pETH_rxLinkCallbackTypeDef rxLinkCallback);
+HAL_StatusTypeDef HAL_ETH_UnRegisterRxLinkCallback(ETH_HandleTypeDef *heth);
+HAL_StatusTypeDef HAL_ETH_GetRxDataErrorCode(ETH_HandleTypeDef *heth, uint32_t *pErrorCode);
+HAL_StatusTypeDef HAL_ETH_RegisterTxFreeCallback(ETH_HandleTypeDef *heth, pETH_txFreeCallbackTypeDef txFreeCallback);
+HAL_StatusTypeDef HAL_ETH_UnRegisterTxFreeCallback(ETH_HandleTypeDef *heth);
+HAL_StatusTypeDef HAL_ETH_ReleaseTxPacket(ETH_HandleTypeDef *heth);
+
+#ifdef HAL_ETH_USE_PTP
+HAL_StatusTypeDef HAL_ETH_PTP_SetConfig(ETH_HandleTypeDef *heth, ETH_PTP_ConfigTypeDef *ptpconfig);
+HAL_StatusTypeDef HAL_ETH_PTP_GetConfig(ETH_HandleTypeDef *heth, ETH_PTP_ConfigTypeDef *ptpconfig);
+HAL_StatusTypeDef HAL_ETH_PTP_SetTime(ETH_HandleTypeDef *heth, ETH_TimeTypeDef *time);
+HAL_StatusTypeDef HAL_ETH_PTP_GetTime(ETH_HandleTypeDef *heth, ETH_TimeTypeDef *time);
+HAL_StatusTypeDef HAL_ETH_PTP_AddTimeOffset(ETH_HandleTypeDef *heth, ETH_PtpUpdateTypeDef ptpoffsettype,
+                                            ETH_TimeTypeDef *timeoffset);
+HAL_StatusTypeDef HAL_ETH_PTP_InsertTxTimestamp(ETH_HandleTypeDef *heth);
+HAL_StatusTypeDef HAL_ETH_PTP_GetTxTimestamp(ETH_HandleTypeDef *heth, ETH_TimeStampTypeDef *timestamp);
+HAL_StatusTypeDef HAL_ETH_PTP_GetRxTimestamp(ETH_HandleTypeDef *heth, ETH_TimeStampTypeDef *timestamp);
+HAL_StatusTypeDef HAL_ETH_RegisterTxPtpCallback(ETH_HandleTypeDef *heth, pETH_txPtpCallbackTypeDef txPtpCallback);
+HAL_StatusTypeDef HAL_ETH_UnRegisterTxPtpCallback(ETH_HandleTypeDef *heth);
+#endif /* HAL_ETH_USE_PTP */
+
+HAL_StatusTypeDef HAL_ETH_Transmit(ETH_HandleTypeDef *heth, ETH_TxPacketConfig *pTxConfig, uint32_t Timeout);
+HAL_StatusTypeDef HAL_ETH_Transmit_IT(ETH_HandleTypeDef *heth, ETH_TxPacketConfig *pTxConfig);
+
+HAL_StatusTypeDef HAL_ETH_WritePHYRegister(ETH_HandleTypeDef *heth, uint32_t PHYAddr, uint32_t PHYReg,
+                                           uint32_t RegValue);
+HAL_StatusTypeDef HAL_ETH_ReadPHYRegister(ETH_HandleTypeDef *heth, uint32_t PHYAddr, uint32_t PHYReg,
+                                          uint32_t *pRegValue);
+
+void              HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth);
+void              HAL_ETH_TxCpltCallback(ETH_HandleTypeDef *heth);
+void              HAL_ETH_RxCpltCallback(ETH_HandleTypeDef *heth);
+void              HAL_ETH_ErrorCallback(ETH_HandleTypeDef *heth);
+void              HAL_ETH_PMTCallback(ETH_HandleTypeDef *heth);
+void              HAL_ETH_WakeUpCallback(ETH_HandleTypeDef *heth);
+void              HAL_ETH_RxAllocateCallback(uint8_t **buff);
+void              HAL_ETH_RxLinkCallback(void **pStart, void **pEnd, uint8_t *buff, uint16_t Length);
+void              HAL_ETH_TxFreeCallback(uint32_t *buff);
+void              HAL_ETH_TxPtpCallback(uint32_t *buff, ETH_TimeStampTypeDef *timestamp);
 /**
   * @}
   */
-
-/* Peripheral Control functions  **********************************************/
 
 /** @addtogroup ETH_Exported_Functions_Group3
   * @{
   */
+/* Peripheral Control functions  **********************************************/
+/* MAC & DMA Configuration APIs  **********************************************/
+HAL_StatusTypeDef HAL_ETH_GetMACConfig(ETH_HandleTypeDef *heth, ETH_MACConfigTypeDef *macconf);
+HAL_StatusTypeDef HAL_ETH_GetDMAConfig(ETH_HandleTypeDef *heth, ETH_DMAConfigTypeDef *dmaconf);
+HAL_StatusTypeDef HAL_ETH_SetMACConfig(ETH_HandleTypeDef *heth, ETH_MACConfigTypeDef *macconf);
+HAL_StatusTypeDef HAL_ETH_SetDMAConfig(ETH_HandleTypeDef *heth, ETH_DMAConfigTypeDef *dmaconf);
+void              HAL_ETH_SetMDIOClockRange(ETH_HandleTypeDef *heth);
 
-HAL_StatusTypeDef HAL_ETH_Start(ETH_HandleTypeDef *heth);
-HAL_StatusTypeDef HAL_ETH_Stop(ETH_HandleTypeDef *heth);
-HAL_StatusTypeDef HAL_ETH_ConfigMAC(ETH_HandleTypeDef *heth, ETH_MACInitTypeDef *macconf);
-HAL_StatusTypeDef HAL_ETH_ConfigDMA(ETH_HandleTypeDef *heth, ETH_DMAInitTypeDef *dmaconf);
+/* MAC VLAN Processing APIs    ************************************************/
+void              HAL_ETH_SetRxVLANIdentifier(ETH_HandleTypeDef *heth, uint32_t ComparisonBits,
+                                              uint32_t VLANIdentifier);
+
+/* MAC L2 Packet Filtering APIs  **********************************************/
+HAL_StatusTypeDef HAL_ETH_GetMACFilterConfig(ETH_HandleTypeDef *heth, ETH_MACFilterConfigTypeDef *pFilterConfig);
+HAL_StatusTypeDef HAL_ETH_SetMACFilterConfig(ETH_HandleTypeDef *heth, ETH_MACFilterConfigTypeDef *pFilterConfig);
+HAL_StatusTypeDef HAL_ETH_SetHashTable(ETH_HandleTypeDef *heth, uint32_t *pHashTable);
+HAL_StatusTypeDef HAL_ETH_SetSourceMACAddrMatch(ETH_HandleTypeDef *heth, uint32_t AddrNbr, uint8_t *pMACAddr);
+
+/* MAC Power Down APIs    *****************************************************/
+void              HAL_ETH_EnterPowerDownMode(ETH_HandleTypeDef *heth, ETH_PowerDownConfigTypeDef *pPowerDownConfig);
+void              HAL_ETH_ExitPowerDownMode(ETH_HandleTypeDef *heth);
+HAL_StatusTypeDef HAL_ETH_SetWakeUpFilter(ETH_HandleTypeDef *heth, uint32_t *pFilter, uint32_t Count);
+
 /**
   * @}
-  */ 
-
-/* Peripheral State functions  ************************************************/
+  */
 
 /** @addtogroup ETH_Exported_Functions_Group4
   * @{
   */
+/* Peripheral State functions  **************************************************/
 HAL_ETH_StateTypeDef HAL_ETH_GetState(ETH_HandleTypeDef *heth);
+uint32_t             HAL_ETH_GetError(ETH_HandleTypeDef *heth);
+uint32_t             HAL_ETH_GetDMAError(ETH_HandleTypeDef *heth);
+uint32_t             HAL_ETH_GetMACError(ETH_HandleTypeDef *heth);
+uint32_t             HAL_ETH_GetMACWakeUpSource(ETH_HandleTypeDef *heth);
 /**
   * @}
   */
@@ -2203,13 +2135,13 @@ HAL_ETH_StateTypeDef HAL_ETH_GetState(ETH_HandleTypeDef *heth);
 /**
   * @}
   */
+
 #endif /* ETH */
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* __STM32F7xx_HAL_ETH_H */
-
+#endif /* STM32F7xx_HAL_ETH_H */
 
 

--- a/Src/stm32f7xx_hal_eth.c
+++ b/Src/stm32f7xx_hal_eth.c
@@ -3,11 +3,11 @@
   * @file    stm32f7xx_hal_eth.c
   * @author  MCD Application Team
   * @brief   ETH HAL module driver.
-  *          This file provides firmware functions to manage the following 
+  *          This file provides firmware functions to manage the following
   *          functionalities of the Ethernet (ETH) peripheral:
-  *           + Initialization and de-initialization functions
+  *           + Initialization and deinitialization functions
   *           + IO operation functions
-  *           + Peripheral Control functions 
+  *           + Peripheral Control functions
   *           + Peripheral State and Errors functions
   *
   ******************************************************************************
@@ -25,89 +25,137 @@
   ==============================================================================
                     ##### How to use this driver #####
   ==============================================================================
-    [..]
+     [..]
+     The ETH HAL driver can be used as follows:
+
       (#)Declare a ETH_HandleTypeDef handle structure, for example:
          ETH_HandleTypeDef  heth;
-        
+
       (#)Fill parameters of Init structure in heth handle
-  
-      (#)Call HAL_ETH_Init() API to initialize the Ethernet peripheral (MAC, DMA, ...) 
+
+      (#)Call HAL_ETH_Init() API to initialize the Ethernet peripheral (MAC, DMA, ...)
 
       (#)Initialize the ETH low level resources through the HAL_ETH_MspInit() API:
-          (##) Enable the Ethernet interface clock using 
-               (+++) __HAL_RCC_ETHMAC_CLK_ENABLE();
-               (+++) __HAL_RCC_ETHMACTX_CLK_ENABLE();
-               (+++) __HAL_RCC_ETHMACRX_CLK_ENABLE();
-           
+          (##) Enable the Ethernet interface clock using
+                (+++)  __HAL_RCC_ETH1MAC_CLK_ENABLE()
+                (+++)  __HAL_RCC_ETH1TX_CLK_ENABLE()
+                (+++)  __HAL_RCC_ETH1RX_CLK_ENABLE()
+
           (##) Initialize the related GPIO clocks
-          (##) Configure Ethernet pin-out
-          (##) Configure Ethernet NVIC interrupt (IT mode)   
-    
-      (#)Initialize Ethernet DMA Descriptors in chain mode and point to allocated buffers:
-          (##) HAL_ETH_DMATxDescListInit(); for Transmission process
-          (##) HAL_ETH_DMARxDescListInit(); for Reception process
+          (##) Configure Ethernet pinout
+          (##) Configure Ethernet NVIC interrupt (in Interrupt mode)
 
-      (#)Enable MAC and DMA transmission and reception:
-          (##) HAL_ETH_Start();
+      (#) Ethernet data reception is asynchronous, so call the following API
+          to start the listening mode:
+          (##) HAL_ETH_Start():
+               This API starts the MAC and DMA transmission and reception process,
+               without enabling end of transfer interrupts, in this mode user
+               has to poll for data reception by calling HAL_ETH_ReadData()
+          (##) HAL_ETH_Start_IT():
+               This API starts the MAC and DMA transmission and reception process,
+               end of transfer interrupts are enabled in this mode,
+               HAL_ETH_RxCpltCallback() will be executed when an Ethernet packet is received
 
-      (#)Prepare ETH DMA TX Descriptors and give the hand to ETH DMA to transfer 
-         the frame to MAC TX FIFO:
-         (##) HAL_ETH_TransmitFrame();
+      (#) When data is received user can call the following API to get received data:
+          (##) HAL_ETH_ReadData(): Read a received packet
 
-      (#)Poll for a received frame in ETH RX DMA Descriptors and get received 
-         frame parameters
-         (##) HAL_ETH_GetReceivedFrame(); (should be called into an infinite loop)
+      (#) For transmission path, two APIs are available:
+         (##) HAL_ETH_Transmit(): Transmit an ETH frame in blocking mode
+         (##) HAL_ETH_Transmit_IT(): Transmit an ETH frame in interrupt mode,
+              HAL_ETH_TxCpltCallback() will be executed when end of transfer occur
 
-      (#) Get a received frame when an ETH RX interrupt occurs:
-         (##) HAL_ETH_GetReceivedFrame_IT(); (called in IT mode only)
-
-      (#) Communicate with external PHY device:
-         (##) Read a specific register from the PHY  
-              HAL_ETH_ReadPHYRegister();
-         (##) Write data to a specific RHY register:
-              HAL_ETH_WritePHYRegister();
+      (#) Communication with an external PHY device:
+         (##) HAL_ETH_ReadPHYRegister(): Read a register from an external PHY
+         (##) HAL_ETH_WritePHYRegister(): Write data to an external RHY register
 
       (#) Configure the Ethernet MAC after ETH peripheral initialization
-          HAL_ETH_ConfigMAC(); all MAC parameters should be filled.
-      
-      (#) Configure the Ethernet DMA after ETH peripheral initialization
-          HAL_ETH_ConfigDMA(); all DMA parameters should be filled.
+          (##) HAL_ETH_GetMACConfig(): Get MAC actual configuration into ETH_MACConfigTypeDef
+          (##) HAL_ETH_SetMACConfig(): Set MAC configuration based on ETH_MACConfigTypeDef
 
-*** Callback registration ***
+      (#) Configure the Ethernet DMA after ETH peripheral initialization
+          (##) HAL_ETH_GetDMAConfig(): Get DMA actual configuration into ETH_DMAConfigTypeDef
+          (##) HAL_ETH_SetDMAConfig(): Set DMA configuration based on ETH_DMAConfigTypeDef
+
+      (#) Configure the Ethernet PTP after ETH peripheral initialization
+          (##) Define HAL_ETH_USE_PTP to use PTP APIs.
+          (##) HAL_ETH_PTP_GetConfig(): Get PTP actual configuration into ETH_PTP_ConfigTypeDef
+          (##) HAL_ETH_PTP_SetConfig(): Set PTP configuration based on ETH_PTP_ConfigTypeDef
+          (##) HAL_ETH_PTP_GetTime(): Get Seconds and Nanoseconds for the Ethernet PTP registers
+          (##) HAL_ETH_PTP_SetTime(): Set Seconds and Nanoseconds for the Ethernet PTP registers
+          (##) HAL_ETH_PTP_AddTimeOffset(): Add Seconds and Nanoseconds offset for the Ethernet PTP registers
+          (##) HAL_ETH_PTP_InsertTxTimestamp(): Insert Timestamp in transmission
+          (##) HAL_ETH_PTP_GetTxTimestamp(): Get transmission timestamp
+          (##) HAL_ETH_PTP_GetRxTimestamp(): Get reception timestamp
+
+      -@- The ARP offload feature is not supported in this driver.
+
+      -@- The PTP offload feature is not supported in this driver.
+
+  *** Callback registration ***
   =============================================
 
   The compilation define  USE_HAL_ETH_REGISTER_CALLBACKS when set to 1
   allows the user to configure dynamically the driver callbacks.
-  Use Function @ref HAL_ETH_RegisterCallback() to register an interrupt callback.
+  Use Function HAL_ETH_RegisterCallback() to register an interrupt callback.
 
-  Function @ref HAL_ETH_RegisterCallback() allows to register following callbacks:
+  Function HAL_ETH_RegisterCallback() allows to register following callbacks:
     (+) TxCpltCallback   : Tx Complete Callback.
     (+) RxCpltCallback   : Rx Complete Callback.
-    (+) DMAErrorCallback : DMA Error Callback.
+    (+) ErrorCallback    : Error Callback.
+    (+) PMTCallback      : Power Management Callback
+    (+) EEECallback      : EEE Callback.
+    (+) WakeUpCallback   : Wake UP Callback
     (+) MspInitCallback  : MspInit Callback.
     (+) MspDeInitCallback: MspDeInit Callback.
 
   This function takes as parameters the HAL peripheral handle, the Callback ID
   and a pointer to the user callback function.
 
-  Use function @ref HAL_ETH_UnRegisterCallback() to reset a callback to the default
+  For specific callbacks RxAllocateCallback use dedicated register callbacks:
+  respectively HAL_ETH_RegisterRxAllocateCallback().
+
+  For specific callbacks RxLinkCallback use dedicated register callbacks:
+  respectively HAL_ETH_RegisterRxLinkCallback().
+
+  For specific callbacks TxFreeCallback use dedicated register callbacks:
+  respectively HAL_ETH_RegisterTxFreeCallback().
+
+  For specific callbacks TxPtpCallback use dedicated register callbacks:
+  respectively HAL_ETH_RegisterTxPtpCallback().
+
+  Use function HAL_ETH_UnRegisterCallback() to reset a callback to the default
   weak function.
-  @ref HAL_ETH_UnRegisterCallback takes as parameters the HAL peripheral handle,
+  HAL_ETH_UnRegisterCallback takes as parameters the HAL peripheral handle,
   and the Callback ID.
   This function allows to reset following callbacks:
     (+) TxCpltCallback   : Tx Complete Callback.
     (+) RxCpltCallback   : Rx Complete Callback.
-    (+) DMAErrorCallback : DMA Error Callback.
+    (+) ErrorCallback    : Error Callback.
+    (+) PMTCallback      : Power Management Callback
+    (+) EEECallback      : EEE Callback.
+    (+) WakeUpCallback   : Wake UP Callback
     (+) MspInitCallback  : MspInit Callback.
     (+) MspDeInitCallback: MspDeInit Callback.
 
+  For specific callbacks RxAllocateCallback use dedicated unregister callbacks:
+  respectively HAL_ETH_UnRegisterRxAllocateCallback().
+
+  For specific callbacks RxLinkCallback use dedicated unregister callbacks:
+  respectively HAL_ETH_UnRegisterRxLinkCallback().
+
+  For specific callbacks TxFreeCallback use dedicated unregister callbacks:
+  respectively HAL_ETH_UnRegisterTxFreeCallback().
+
+  For specific callbacks TxPtpCallback use dedicated unregister callbacks:
+  respectively HAL_ETH_UnRegisterTxPtpCallback().
+
   By default, after the HAL_ETH_Init and when the state is HAL_ETH_STATE_RESET
   all callbacks are set to the corresponding weak functions:
-  examples @ref HAL_ETH_TxCpltCallback(), @ref HAL_ETH_RxCpltCallback().
+  examples HAL_ETH_TxCpltCallback(), HAL_ETH_RxCpltCallback().
   Exception done for MspInit and MspDeInit functions that are
-  reset to the legacy weak function in the HAL_ETH_Init/ @ref HAL_ETH_DeInit only when
+  reset to the legacy weak function in the HAL_ETH_Init/ HAL_ETH_DeInit only when
   these callbacks are null (not registered beforehand).
-  if not, MspInit or MspDeInit are not null, the HAL_ETH_Init/ @ref HAL_ETH_DeInit
+  if not, MspInit or MspDeInit are not null, the HAL_ETH_Init/ HAL_ETH_DeInit
   keep and use the user MspInit/MspDeInit callbacks (registered beforehand)
 
   Callbacks can be registered/unregistered in HAL_ETH_STATE_READY state only.
@@ -115,7 +163,7 @@
   in HAL_ETH_STATE_READY or HAL_ETH_STATE_RESET state,
   thus registered (user) MspInit/DeInit callbacks can be used during the Init/DeInit.
   In that case first register the MspInit/MspDeInit user callbacks
-  using @ref HAL_ETH_RegisterCallback() before calling @ref HAL_ETH_DeInit
+  using HAL_ETH_RegisterCallback() before calling HAL_ETH_DeInit
   or HAL_ETH_Init function.
 
   When The compilation define USE_HAL_ETH_REGISTER_CALLBACKS is set to 0 or
@@ -132,531 +180,274 @@
 /** @addtogroup STM32F7xx_HAL_Driver
   * @{
   */
+#ifdef HAL_ETH_MODULE_ENABLED
 
-/** @defgroup ETH ETH 
+#if defined(ETH)
+
+/** @defgroup ETH ETH
   * @brief ETH HAL module driver
   * @{
   */
 
-#ifdef HAL_ETH_MODULE_ENABLED
-#if defined (ETH)
-
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
-/** @defgroup ETH_Private_Constants ETH Private Constants
+/** @addtogroup ETH_Private_Constants ETH Private Constants
   * @{
   */
-#define ETH_TIMEOUT_SWRESET                 ((uint32_t)500)  
-#define ETH_TIMEOUT_LINKED_STATE          ((uint32_t)5000)  
-#define ETH_TIMEOUT_AUTONEGO_COMPLETED    ((uint32_t)5000) 
+#define ETH_MACCR_MASK       ((uint32_t)0xFFFB7F7CU)
+#define ETH_MACECR_MASK      ((uint32_t)0x3F077FFFU)
+#define ETH_MACFFR_MASK      ((uint32_t)0x800007FFU)
+#define ETH_MACWTR_MASK      ((uint32_t)0x0000010FU)
+#define ETH_MACTFCR_MASK     ((uint32_t)0xFFFF00F2U)
+#define ETH_MACRFCR_MASK     ((uint32_t)0x00000003U)
+#define ETH_MTLTQOMR_MASK    ((uint32_t)0x00000072U)
+#define ETH_MTLRQOMR_MASK    ((uint32_t)0x0000007BU)
 
+#define ETH_DMAMR_MASK       ((uint32_t)0x00007802U)
+#define ETH_DMASBMR_MASK     ((uint32_t)0x0000D001U)
+#define ETH_DMACCR_MASK      ((uint32_t)0x00013FFFU)
+#define ETH_DMACTCR_MASK     ((uint32_t)0x003F1010U)
+#define ETH_DMACRCR_MASK     ((uint32_t)0x803F0000U)
+#define ETH_MACPMTCSR_MASK   (ETH_MACPMTCSR_PD | ETH_MACPMTCSR_WFE | \
+                              ETH_MACPMTCSR_MPE | ETH_MACPMTCSR_GU)
+
+/* Timeout values */
+#define ETH_SWRESET_TIMEOUT                 ((uint32_t)500U)
+#define ETH_MDIO_BUS_TIMEOUT                ((uint32_t)1000U)
+
+#define ETH_DMARXDESC_ERRORS_MASK ((uint32_t)(ETH_DMARXDESC_DBE | ETH_DMARXDESC_RE | \
+                                              ETH_DMARXDESC_OE  | ETH_DMARXDESC_RWT |\
+                                              ETH_DMARXDESC_LC | ETH_DMARXDESC_CE |\
+                                              ETH_DMARXDESC_DE | ETH_DMARXDESC_IPV4HCE))
+
+#define ETH_MAC_US_TICK               ((uint32_t)1000000U)
+
+#define ETH_MACTSCR_MASK              ((uint32_t)0x0087FF2FU)
+
+#define ETH_PTPTSHR_VALUE            ((uint32_t)0xFFFFFFFFU)
+#define ETH_PTPTSLR_VALUE            ((uint32_t)0xBB9ACA00U)
+
+/* Ethernet MACMIIAR register Mask */
+#define ETH_MACMIIAR_CR_MASK    ((uint32_t)0xFFFFFFE3U)
+
+/* Delay to wait when writing to some Ethernet registers */
+#define ETH_REG_WRITE_DELAY ((uint32_t)0x00000001U)
+
+/* ETHERNET MACCR register Mask */
+#define ETH_MACCR_CLEAR_MASK    0xFF20810FU
+
+/* ETHERNET MACFCR register Mask */
+#define ETH_MACFCR_CLEAR_MASK   0x0000FF41U
+
+/* ETHERNET DMAOMR register Mask */
+#define ETH_DMAOMR_CLEAR_MASK   0xF8DE3F23U
+
+/* ETHERNET MAC address offsets */
+#define ETH_MAC_ADDR_HBASE    (uint32_t)(ETH_MAC_BASE + 0x40U)  /* ETHERNET MAC address high offset */
+#define ETH_MAC_ADDR_LBASE    (uint32_t)(ETH_MAC_BASE + 0x44U)  /* ETHERNET MAC address low offset */
+
+/* ETHERNET DMA Rx descriptors Frame length Shift */
+#define  ETH_DMARXDESC_FRAMELENGTHSHIFT            16U
 /**
   * @}
   */
-/* Private macro -------------------------------------------------------------*/
-/* Private variables ---------------------------------------------------------*/
-/* Private function prototypes -----------------------------------------------*/
-/** @defgroup ETH_Private_Functions ETH Private Functions
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup ETH_Private_Macros ETH Private Macros
   * @{
   */
-static void ETH_MACDMAConfig(ETH_HandleTypeDef *heth, uint32_t err);
-static void ETH_MACAddressConfig(ETH_HandleTypeDef *heth, uint32_t MacAddr, uint8_t *Addr);
-static void ETH_MACReceptionEnable(ETH_HandleTypeDef *heth);
-static void ETH_MACReceptionDisable(ETH_HandleTypeDef *heth);
-static void ETH_MACTransmissionEnable(ETH_HandleTypeDef *heth);
-static void ETH_MACTransmissionDisable(ETH_HandleTypeDef *heth);
-static void ETH_DMATransmissionEnable(ETH_HandleTypeDef *heth);
-static void ETH_DMATransmissionDisable(ETH_HandleTypeDef *heth);
-static void ETH_DMAReceptionEnable(ETH_HandleTypeDef *heth);
-static void ETH_DMAReceptionDisable(ETH_HandleTypeDef *heth);
+/* Helper macros for TX descriptor handling */
+#define INCR_TX_DESC_INDEX(inx, offset) do {\
+                                             (inx) += (offset);\
+                                             if ((inx) >= (uint32_t)ETH_TX_DESC_CNT){\
+                                             (inx) = ((inx) - (uint32_t)ETH_TX_DESC_CNT);}\
+                                           } while (0)
+
+/* Helper macros for RX descriptor handling */
+#define INCR_RX_DESC_INDEX(inx, offset) do {\
+                                             (inx) += (offset);\
+                                             if ((inx) >= (uint32_t)ETH_RX_DESC_CNT){\
+                                             (inx) = ((inx) - (uint32_t)ETH_RX_DESC_CNT);}\
+                                           } while (0)
+/**
+  * @}
+  */
+/* Private function prototypes -----------------------------------------------*/
+/** @defgroup ETH_Private_Functions   ETH Private Functions
+  * @{
+  */
+static void ETH_SetMACConfig(ETH_HandleTypeDef *heth,  ETH_MACConfigTypeDef *macconf);
+static void ETH_SetDMAConfig(ETH_HandleTypeDef *heth,  ETH_DMAConfigTypeDef *dmaconf);
+static void ETH_MACDMAConfig(ETH_HandleTypeDef *heth);
+static void ETH_DMATxDescListInit(ETH_HandleTypeDef *heth);
+static void ETH_DMARxDescListInit(ETH_HandleTypeDef *heth);
+static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, ETH_TxPacketConfig *pTxConfig, uint32_t ItMode);
+static void ETH_UpdateDescriptor(ETH_HandleTypeDef *heth);
 static void ETH_FlushTransmitFIFO(ETH_HandleTypeDef *heth);
+static void ETH_MACAddressConfig(ETH_HandleTypeDef *heth, uint32_t MacAddr, uint8_t *Addr);
+
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
 static void ETH_InitCallbacksToDefault(ETH_HandleTypeDef *heth);
 #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
-
 /**
   * @}
   */
-/* Private functions ---------------------------------------------------------*/
 
+/* Exported functions ---------------------------------------------------------*/
 /** @defgroup ETH_Exported_Functions ETH Exported Functions
   * @{
   */
 
-/** @defgroup ETH_Exported_Functions_Group1 Initialization and de-initialization functions 
-  *  @brief   Initialization and Configuration functions 
+/** @defgroup ETH_Exported_Functions_Group1 Initialization and deinitialization functions
+  *  @brief    Initialization and Configuration functions
   *
-  @verbatim    
-  ===============================================================================
-            ##### Initialization and de-initialization functions #####
-  ===============================================================================
-  [..]  This section provides functions allowing to:
-      (+) Initialize and configure the Ethernet peripheral
-      (+) De-initialize the Ethernet peripheral
+@verbatim
+===============================================================================
+            ##### Initialization and Configuration functions #####
+ ===============================================================================
+    [..]  This subsection provides a set of functions allowing to initialize and
+          deinitialize the ETH peripheral:
 
-  @endverbatim
+      (+) User must Implement HAL_ETH_MspInit() function in which he configures
+          all related peripherals resources (CLOCK, GPIO and NVIC ).
+
+      (+) Call the function HAL_ETH_Init() to configure the selected device with
+          the selected configuration:
+        (++) MAC address
+        (++) Media interface (MII or RMII)
+        (++) Rx DMA Descriptors Tab
+        (++) Tx DMA Descriptors Tab
+        (++) Length of Rx Buffers
+
+      (+) Call the function HAL_ETH_DeInit() to restore the default configuration
+          of the selected ETH peripheral.
+
+@endverbatim
   * @{
   */
 
 /**
-  * @brief  Initializes the Ethernet MAC and DMA according to default
-  *         parameters.
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
+  * @brief  Initialize the Ethernet peripheral registers.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
   *         the configuration information for ETHERNET module
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth)
 {
-  uint32_t tempreg = 0, phyreg = 0;
-  uint32_t hclk = 60000000;
-  uint32_t tickstart = 0;
-  uint32_t err = ETH_SUCCESS;
-  
-  /* Check the ETH peripheral state */
-  if(heth == NULL)
+  uint32_t tickstart;
+
+  if (heth == NULL)
   {
     return HAL_ERROR;
   }
-  
-  /* Check parameters */
-  assert_param(IS_ETH_AUTONEGOTIATION(heth->Init.AutoNegotiation));
-  assert_param(IS_ETH_RX_MODE(heth->Init.RxMode));
-  assert_param(IS_ETH_CHECKSUM_MODE(heth->Init.ChecksumMode));
-  assert_param(IS_ETH_MEDIA_INTERFACE(heth->Init.MediaInterface));  
-  
-  if(heth->State == HAL_ETH_STATE_RESET)
+  if (heth->gState == HAL_ETH_STATE_RESET)
   {
-    /* Allocate lock resource and initialize it */
-    heth->Lock = HAL_UNLOCKED;
+    heth->gState = HAL_ETH_STATE_BUSY;
+
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
+
     ETH_InitCallbacksToDefault(heth);
 
-    if(heth->MspInitCallback == NULL)
+    if (heth->MspInitCallback == NULL)
     {
-      /* Init the low level hardware : GPIO, CLOCK, NVIC. */
       heth->MspInitCallback = HAL_ETH_MspInit;
     }
-    heth->MspInitCallback(heth);
 
+    /* Init the low level hardware */
+    heth->MspInitCallback(heth);
 #else
     /* Init the low level hardware : GPIO, CLOCK, NVIC. */
     HAL_ETH_MspInit(heth);
-#endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
+
+#endif /* (USE_HAL_ETH_REGISTER_CALLBACKS) */
   }
-  
-  /* Enable SYSCFG Clock */
+
   __HAL_RCC_SYSCFG_CLK_ENABLE();
-  
+
   /* Select MII or RMII Mode*/
   SYSCFG->PMC &= ~(SYSCFG_PMC_MII_RMII_SEL);
   SYSCFG->PMC |= (uint32_t)heth->Init.MediaInterface;
-  
+  /* Dummy read to sync SYSCFG with ETH */
+  (void)SYSCFG->PMC;
+
   /* Ethernet Software reset */
   /* Set the SWR bit: resets all MAC subsystem internal registers and logic */
   /* After reset all the registers holds their respective reset values */
-  (heth->Instance)->DMABMR |= ETH_DMABMR_SR;
-  
+  SET_BIT(heth->Instance->DMABMR, ETH_DMABMR_SR);
+
   /* Get tick */
   tickstart = HAL_GetTick();
-  
-  /* Wait for software reset */
-  while (((heth->Instance)->DMABMR & ETH_DMABMR_SR) != (uint32_t)RESET)
-  {
-    /* Check for the Timeout */
-    if((HAL_GetTick() - tickstart ) > ETH_TIMEOUT_SWRESET)
-    {     
-      heth->State= HAL_ETH_STATE_TIMEOUT;
-  
-      /* Process Unlocked */
-      __HAL_UNLOCK(heth);
-    
-      /* Note: The SWR is not performed if the ETH_RX_CLK or the ETH_TX_CLK are  
-         not available, please check your external PHY or the IO configuration */
-               
-      return HAL_TIMEOUT;
-    }
-  }
-  
-  /*-------------------------------- MAC Initialization ----------------------*/
-  /* Get the ETHERNET MACMIIAR value */
-  tempreg = (heth->Instance)->MACMIIAR;
-  /* Clear CSR Clock Range CR[2:0] bits */
-  tempreg &= ETH_MACMIIAR_CR_MASK;
-  
-  /* Get hclk frequency value */
-  hclk = HAL_RCC_GetHCLKFreq();
-  
-  /* Set CR bits depending on hclk value */
-  if((hclk >= 20000000)&&(hclk < 35000000))
-  {
-    /* CSR Clock Range between 20-35 MHz */
-    tempreg |= (uint32_t)ETH_MACMIIAR_CR_Div16;
-  }
-  else if((hclk >= 35000000)&&(hclk < 60000000))
-  {
-    /* CSR Clock Range between 35-60 MHz */ 
-    tempreg |= (uint32_t)ETH_MACMIIAR_CR_Div26;
-  }  
-  else if((hclk >= 60000000)&&(hclk < 100000000))
-  {
-    /* CSR Clock Range between 60-100 MHz */ 
-    tempreg |= (uint32_t)ETH_MACMIIAR_CR_Div42;
-  }  
-  else if((hclk >= 100000000)&&(hclk < 150000000))
-  {
-    /* CSR Clock Range between 100-150 MHz */ 
-    tempreg |= (uint32_t)ETH_MACMIIAR_CR_Div62;
-  }
-  else /* ((hclk >= 150000000)&&(hclk <= 216000000)) */
-  {
-    /* CSR Clock Range between 150-216 MHz */ 
-    tempreg |= (uint32_t)ETH_MACMIIAR_CR_Div102;    
-  }
-  
-  /* Write to ETHERNET MAC MIIAR: Configure the ETHERNET CSR Clock Range */
-  (heth->Instance)->MACMIIAR = (uint32_t)tempreg;
-  
-  /*-------------------- PHY initialization and configuration ----------------*/
-  /* Put the PHY in reset mode */
-  if((HAL_ETH_WritePHYRegister(heth, PHY_BCR, PHY_RESET)) != HAL_OK)
-  {
-    /* In case of write timeout */
-    err = ETH_ERROR;
-    
-    /* Config MAC and DMA */
-    ETH_MACDMAConfig(heth, err);
-    
-    /* Set the ETH peripheral state to READY */
-    heth->State = HAL_ETH_STATE_READY;
-    
-    /* Return HAL_ERROR */
-    return HAL_ERROR;
-  }
-  
-  /* Delay to assure PHY reset */
-  HAL_Delay(PHY_RESET_DELAY);
-  
-  if((heth->Init).AutoNegotiation != ETH_AUTONEGOTIATION_DISABLE)
-  {
-    /* Get tick */
-    tickstart = HAL_GetTick();
-    
-    /* We wait for linked status */
-    do
-    {
-      HAL_ETH_ReadPHYRegister(heth, PHY_BSR, &phyreg);
-      
-      /* Check for the Timeout */
-      if((HAL_GetTick() - tickstart ) > ETH_TIMEOUT_LINKED_STATE)
-      {
-        /* In case of write timeout */
-        err = ETH_ERROR;
-      
-        /* Config MAC and DMA */
-        ETH_MACDMAConfig(heth, err);
-        
-        heth->State= HAL_ETH_STATE_READY;
-  
-        /* Process Unlocked */
-        __HAL_UNLOCK(heth);
-    
-        return HAL_TIMEOUT;
-      }
-    } while (((phyreg & PHY_LINKED_STATUS) != PHY_LINKED_STATUS));
 
-    
-    /* Enable Auto-Negotiation */
-    if((HAL_ETH_WritePHYRegister(heth, PHY_BCR, PHY_AUTONEGOTIATION)) != HAL_OK)
-    {
-      /* In case of write timeout */
-      err = ETH_ERROR;
-      
-      /* Config MAC and DMA */
-      ETH_MACDMAConfig(heth, err);
-      
-      /* Set the ETH peripheral state to READY */
-      heth->State = HAL_ETH_STATE_READY;
-      
-      /* Return HAL_ERROR */
-      return HAL_ERROR;   
-    }
-    
-    /* Get tick */
-    tickstart = HAL_GetTick();
-    
-    /* Wait until the auto-negotiation will be completed */
-    do
-    {
-      HAL_ETH_ReadPHYRegister(heth, PHY_BSR, &phyreg);
-      
-      /* Check for the Timeout */
-      if((HAL_GetTick() - tickstart ) > ETH_TIMEOUT_AUTONEGO_COMPLETED)
-      {
-        /* In case of write timeout */
-        err = ETH_ERROR;
-      
-        /* Config MAC and DMA */
-        ETH_MACDMAConfig(heth, err);
-        
-        heth->State= HAL_ETH_STATE_READY;
-  
-        /* Process Unlocked */
-        __HAL_UNLOCK(heth);
-    
-        return HAL_TIMEOUT;
-      }
-      
-    } while (((phyreg & PHY_AUTONEGO_COMPLETE) != PHY_AUTONEGO_COMPLETE));
-    
-    /* Read the result of the auto-negotiation */
-    if((HAL_ETH_ReadPHYRegister(heth, PHY_SR, &phyreg)) != HAL_OK)
-    {
-      /* In case of write timeout */
-      err = ETH_ERROR;
-      
-      /* Config MAC and DMA */
-      ETH_MACDMAConfig(heth, err);
-      
-      /* Set the ETH peripheral state to READY */
-      heth->State = HAL_ETH_STATE_READY;
-      
-      /* Return HAL_ERROR */
-      return HAL_ERROR;   
-    }
-    
-    /* Configure the MAC with the Duplex Mode fixed by the auto-negotiation process */
-    if((phyreg & PHY_DUPLEX_STATUS) != (uint32_t)RESET)
-    {
-      /* Set Ethernet duplex mode to Full-duplex following the auto-negotiation */
-      (heth->Init).DuplexMode = ETH_MODE_FULLDUPLEX;  
-    }
-    else
-    {
-      /* Set Ethernet duplex mode to Half-duplex following the auto-negotiation */
-      (heth->Init).DuplexMode = ETH_MODE_HALFDUPLEX;           
-    }
-    /* Configure the MAC with the speed fixed by the auto-negotiation process */
-    if((phyreg & PHY_SPEED_STATUS) == PHY_SPEED_STATUS)
-    {  
-      /* Set Ethernet speed to 10M following the auto-negotiation */
-      (heth->Init).Speed = ETH_SPEED_10M; 
-    }
-    else
-    {   
-      /* Set Ethernet speed to 100M following the auto-negotiation */ 
-      (heth->Init).Speed = ETH_SPEED_100M;
-    }
-  }
-  else /* AutoNegotiation Disable */
+  /* Wait for software reset */
+  while (READ_BIT(heth->Instance->DMABMR, ETH_DMABMR_SR) > 0U)
   {
-    /* Check parameters */
-    assert_param(IS_ETH_SPEED(heth->Init.Speed));
-    assert_param(IS_ETH_DUPLEX_MODE(heth->Init.DuplexMode));
-    
-    /* Set MAC Speed and Duplex Mode */
-    if(HAL_ETH_WritePHYRegister(heth, PHY_BCR, ((uint16_t)((heth->Init).DuplexMode >> 3) |
-                                                (uint16_t)((heth->Init).Speed >> 1))) != HAL_OK)
+    if (((HAL_GetTick() - tickstart) > ETH_SWRESET_TIMEOUT))
     {
-      /* In case of write timeout */
-      err = ETH_ERROR;
-      
-      /* Config MAC and DMA */
-      ETH_MACDMAConfig(heth, err);
-      
-      /* Set the ETH peripheral state to READY */
-      heth->State = HAL_ETH_STATE_READY;
-      
-      /* Return HAL_ERROR */
+      /* Set Error Code */
+      heth->ErrorCode = HAL_ETH_ERROR_TIMEOUT;
+      /* Set State as Error */
+      heth->gState = HAL_ETH_STATE_ERROR;
+      /* Return Error */
       return HAL_ERROR;
-    }  
-    
-    /* Delay to assure PHY configuration */
-    HAL_Delay(PHY_CONFIG_DELAY);
+    }
   }
-  
-  /* Config MAC and DMA */
-  ETH_MACDMAConfig(heth, err);
-  
-  /* Set ETH HAL State to Ready */
-  heth->State= HAL_ETH_STATE_READY;
-  
-  /* Return function status */
+
+
+  /*------------------ MAC, MTL and DMA default Configuration ----------------*/
+  ETH_MACDMAConfig(heth);
+
+
+  /*------------------ DMA Tx Descriptors Configuration ----------------------*/
+  ETH_DMATxDescListInit(heth);
+
+  /*------------------ DMA Rx Descriptors Configuration ----------------------*/
+  ETH_DMARxDescListInit(heth);
+
+  /*--------------------- ETHERNET MAC Address Configuration ------------------*/
+  ETH_MACAddressConfig(heth, ETH_MAC_ADDRESS0, heth->Init.MACAddr);
+
+  heth->ErrorCode = HAL_ETH_ERROR_NONE;
+  heth->gState = HAL_ETH_STATE_READY;
+
   return HAL_OK;
 }
 
 /**
-  * @brief  De-Initializes the ETH peripheral. 
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
+  * @brief  DeInitializes the ETH peripheral.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
   *         the configuration information for ETHERNET module
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_ETH_DeInit(ETH_HandleTypeDef *heth)
 {
   /* Set the ETH peripheral state to BUSY */
-  heth->State = HAL_ETH_STATE_BUSY;
-  
+  heth->gState = HAL_ETH_STATE_BUSY;
+
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
-  if(heth->MspDeInitCallback == NULL)
+
+  if (heth->MspDeInitCallback == NULL)
   {
     heth->MspDeInitCallback = HAL_ETH_MspDeInit;
   }
-  /* De-Init the low level hardware : GPIO, CLOCK, NVIC. */
+  /* DeInit the low level hardware */
   heth->MspDeInitCallback(heth);
 #else
+
   /* De-Init the low level hardware : GPIO, CLOCK, NVIC. */
   HAL_ETH_MspDeInit(heth);
-#endif
-  
+
+#endif /* (USE_HAL_ETH_REGISTER_CALLBACKS) */
+
   /* Set ETH HAL state to Disabled */
-  heth->State= HAL_ETH_STATE_RESET;
+  heth->gState = HAL_ETH_STATE_RESET;
 
-  /* Release Lock */
-  __HAL_UNLOCK(heth);
-
-  /* Return function status */
-  return HAL_OK;
-}
-
-/**
-  * @brief  Initializes the DMA Tx descriptors in chain mode.
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module  
-  * @param  DMATxDescTab Pointer to the first Tx desc list 
-  * @param  TxBuff Pointer to the first TxBuffer list
-  * @param  TxBuffCount Number of the used Tx desc in the list
-  * @retval HAL status
-  */
-HAL_StatusTypeDef HAL_ETH_DMATxDescListInit(ETH_HandleTypeDef *heth, ETH_DMADescTypeDef *DMATxDescTab, uint8_t *TxBuff, uint32_t TxBuffCount)
-{
-  uint32_t i = 0;
-  ETH_DMADescTypeDef *dmatxdesc;
-  
-  /* Process Locked */
-  __HAL_LOCK(heth);
-  
-  /* Set the ETH peripheral state to BUSY */
-  heth->State = HAL_ETH_STATE_BUSY;
-  
-  /* Set the DMATxDescToSet pointer with the first one of the DMATxDescTab list */
-  heth->TxDesc = DMATxDescTab;
-  
-  /* Fill each DMATxDesc descriptor with the right values */   
-  for(i=0; i < TxBuffCount; i++)
-  {
-    /* Get the pointer on the member (i) of the Tx Desc list */
-    dmatxdesc = DMATxDescTab + i;
-    
-    /* Set Second Address Chained bit */
-    dmatxdesc->Status = ETH_DMATXDESC_TCH;  
-    
-    /* Set Buffer1 address pointer */
-    dmatxdesc->Buffer1Addr = (uint32_t)(&TxBuff[i*ETH_TX_BUF_SIZE]);
-    
-    if ((heth->Init).ChecksumMode == ETH_CHECKSUM_BY_HARDWARE)
-    {
-      /* Set the DMA Tx descriptors checksum insertion */
-      dmatxdesc->Status |= ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL;
-    }
-    
-    /* Initialize the next descriptor with the Next Descriptor Polling Enable */
-    if(i < (TxBuffCount-1))
-    {
-      /* Set next descriptor address register with next descriptor base address */
-      dmatxdesc->Buffer2NextDescAddr = (uint32_t)(DMATxDescTab+i+1);
-    }
-    else
-    {
-      /* For last descriptor, set next descriptor address register equal to the first descriptor base address */ 
-      dmatxdesc->Buffer2NextDescAddr = (uint32_t) DMATxDescTab;  
-    }
-  }
-  
-  /* Set Transmit Descriptor List Address Register */
-  (heth->Instance)->DMATDLAR = (uint32_t) DMATxDescTab;
-  
-  /* Set ETH HAL State to Ready */
-  heth->State= HAL_ETH_STATE_READY;
-  
-  /* Process Unlocked */
-  __HAL_UNLOCK(heth);
-  
-  /* Return function status */
-  return HAL_OK;
-}
-
-/**
-  * @brief  Initializes the DMA Rx descriptors in chain mode.
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module  
-  * @param  DMARxDescTab Pointer to the first Rx desc list 
-  * @param  RxBuff Pointer to the first RxBuffer list
-  * @param  RxBuffCount Number of the used Rx desc in the list
-  * @retval HAL status
-  */
-HAL_StatusTypeDef HAL_ETH_DMARxDescListInit(ETH_HandleTypeDef *heth, ETH_DMADescTypeDef *DMARxDescTab, uint8_t *RxBuff, uint32_t RxBuffCount)
-{
-  uint32_t i = 0;
-  ETH_DMADescTypeDef *DMARxDesc;
-  
-  /* Process Locked */
-  __HAL_LOCK(heth);
-  
-  /* Set the ETH peripheral state to BUSY */
-  heth->State = HAL_ETH_STATE_BUSY;
-  
-  /* Set the Ethernet RxDesc pointer with the first one of the DMARxDescTab list */
-  heth->RxDesc = DMARxDescTab; 
-  
-  /* Fill each DMARxDesc descriptor with the right values */
-  for(i=0; i < RxBuffCount; i++)
-  {
-    /* Get the pointer on the member (i) of the Rx Desc list */
-    DMARxDesc = DMARxDescTab+i;
-    
-    /* Set Own bit of the Rx descriptor Status */
-    DMARxDesc->Status = ETH_DMARXDESC_OWN;
-    
-    /* Set Buffer1 size and Second Address Chained bit */
-    DMARxDesc->ControlBufferSize = ETH_DMARXDESC_RCH | ETH_RX_BUF_SIZE;  
-    
-    /* Set Buffer1 address pointer */
-    DMARxDesc->Buffer1Addr = (uint32_t)(&RxBuff[i*ETH_RX_BUF_SIZE]);
-    
-    if((heth->Init).RxMode == ETH_RXINTERRUPT_MODE)
-    {
-      /* Enable Ethernet DMA Rx Descriptor interrupt */
-      DMARxDesc->ControlBufferSize &= ~ETH_DMARXDESC_DIC;
-    }
-    
-    /* Initialize the next descriptor with the Next Descriptor Polling Enable */
-    if(i < (RxBuffCount-1))
-    {
-      /* Set next descriptor address register with next descriptor base address */
-      DMARxDesc->Buffer2NextDescAddr = (uint32_t)(DMARxDescTab+i+1); 
-    }
-    else
-    {
-      /* For last descriptor, set next descriptor address register equal to the first descriptor base address */ 
-      DMARxDesc->Buffer2NextDescAddr = (uint32_t)(DMARxDescTab); 
-    }
-  }
-  
-  /* Set Receive Descriptor List Address Register */
-  (heth->Instance)->DMARDLAR = (uint32_t) DMARxDescTab;
-  
-  /* Set ETH HAL State to Ready */
-  heth->State= HAL_ETH_STATE_READY;
-  
-  /* Process Unlocked */
-  __HAL_UNLOCK(heth);
-  
   /* Return function status */
   return HAL_OK;
 }
 
 /**
   * @brief  Initializes the ETH MSP.
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
   *         the configuration information for ETHERNET module
   * @retval None
   */
@@ -664,7 +455,6 @@ __weak void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(heth);
- 
   /* NOTE : This function Should not be modified, when the callback is needed,
   the HAL_ETH_MspInit could be implemented in the user file
   */
@@ -672,7 +462,7 @@ __weak void HAL_ETH_MspInit(ETH_HandleTypeDef *heth)
 
 /**
   * @brief  DeInitializes ETH MSP.
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
   *         the configuration information for ETHERNET module
   * @retval None
   */
@@ -680,7 +470,6 @@ __weak void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(heth);
- 
   /* NOTE : This function Should not be modified, when the callback is needed,
   the HAL_ETH_MspDeInit could be implemented in the user file
   */
@@ -695,79 +484,95 @@ __weak void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
   *        This parameter can be one of the following values:
   *          @arg @ref HAL_ETH_TX_COMPLETE_CB_ID Tx Complete Callback ID
   *          @arg @ref HAL_ETH_RX_COMPLETE_CB_ID Rx Complete Callback ID
-  *          @arg @ref HAL_ETH_DMA_ERROR_CB_ID   DMA Error Callback ID
+  *          @arg @ref HAL_ETH_ERROR_CB_ID       Error Callback ID
+  *          @arg @ref HAL_ETH_PMT_CB_ID         Power Management Callback ID
+  *          @arg @ref HAL_ETH_WAKEUP_CB_ID      Wake UP Callback ID
   *          @arg @ref HAL_ETH_MSPINIT_CB_ID     MspInit callback ID
   *          @arg @ref HAL_ETH_MSPDEINIT_CB_ID   MspDeInit callback ID
   * @param pCallback pointer to the Callback function
   * @retval status
   */
-HAL_StatusTypeDef HAL_ETH_RegisterCallback(ETH_HandleTypeDef *heth, HAL_ETH_CallbackIDTypeDef CallbackID, pETH_CallbackTypeDef pCallback)
+HAL_StatusTypeDef HAL_ETH_RegisterCallback(ETH_HandleTypeDef *heth, HAL_ETH_CallbackIDTypeDef CallbackID,
+                                           pETH_CallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  if(pCallback == NULL)
+  if (pCallback == NULL)
   {
+    /* Update the error code */
+    heth->ErrorCode |= HAL_ETH_ERROR_INVALID_CALLBACK;
+
     return HAL_ERROR;
   }
-  /* Process locked */
-  __HAL_LOCK(heth);
 
-  if(heth->State == HAL_ETH_STATE_READY)
+  if (heth->gState == HAL_ETH_STATE_READY)
   {
     switch (CallbackID)
     {
-    case HAL_ETH_TX_COMPLETE_CB_ID :
-      heth->TxCpltCallback = pCallback;
-      break;
+      case HAL_ETH_TX_COMPLETE_CB_ID :
+        heth->TxCpltCallback = pCallback;
+        break;
 
-    case HAL_ETH_RX_COMPLETE_CB_ID :
-      heth->RxCpltCallback = pCallback;
-      break;
+      case HAL_ETH_RX_COMPLETE_CB_ID :
+        heth->RxCpltCallback = pCallback;
+        break;
 
-    case HAL_ETH_DMA_ERROR_CB_ID :
-      heth->DMAErrorCallback = pCallback;
-      break;
+      case HAL_ETH_ERROR_CB_ID :
+        heth->ErrorCallback = pCallback;
+        break;
 
-    case HAL_ETH_MSPINIT_CB_ID :
-      heth->MspInitCallback = pCallback;
-      break;
+      case HAL_ETH_PMT_CB_ID :
+        heth->PMTCallback = pCallback;
+        break;
 
-    case HAL_ETH_MSPDEINIT_CB_ID :
-      heth->MspDeInitCallback = pCallback;
-      break;
 
-    default :
-      /* Return error status */
-      status =  HAL_ERROR;
-      break;
+      case HAL_ETH_WAKEUP_CB_ID :
+        heth->WakeUpCallback = pCallback;
+        break;
+
+      case HAL_ETH_MSPINIT_CB_ID :
+        heth->MspInitCallback = pCallback;
+        break;
+
+      case HAL_ETH_MSPDEINIT_CB_ID :
+        heth->MspDeInitCallback = pCallback;
+        break;
+
+      default :
+        /* Update the error code */
+        heth->ErrorCode |= HAL_ETH_ERROR_INVALID_CALLBACK;
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
     }
   }
-  else if(heth->State == HAL_ETH_STATE_RESET)
+  else if (heth->gState == HAL_ETH_STATE_RESET)
   {
     switch (CallbackID)
     {
-    case HAL_ETH_MSPINIT_CB_ID :
-      heth->MspInitCallback = pCallback;
-      break;
+      case HAL_ETH_MSPINIT_CB_ID :
+        heth->MspInitCallback = pCallback;
+        break;
 
-    case HAL_ETH_MSPDEINIT_CB_ID :
-      heth->MspDeInitCallback = pCallback;
-      break;
+      case HAL_ETH_MSPDEINIT_CB_ID :
+        heth->MspDeInitCallback = pCallback;
+        break;
 
-    default :
-      /* Return error status */
-      status =  HAL_ERROR;
-      break;
+      default :
+        /* Update the error code */
+        heth->ErrorCode |= HAL_ETH_ERROR_INVALID_CALLBACK;
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
     }
   }
   else
   {
+    /* Update the error code */
+    heth->ErrorCode |= HAL_ETH_ERROR_INVALID_CALLBACK;
     /* Return error status */
     status =  HAL_ERROR;
   }
-
-  /* Release Lock */
-  __HAL_UNLOCK(heth);
 
   return status;
 }
@@ -780,7 +585,9 @@ HAL_StatusTypeDef HAL_ETH_RegisterCallback(ETH_HandleTypeDef *heth, HAL_ETH_Call
   *        This parameter can be one of the following values:
   *          @arg @ref HAL_ETH_TX_COMPLETE_CB_ID Tx Complete Callback ID
   *          @arg @ref HAL_ETH_RX_COMPLETE_CB_ID Rx Complete Callback ID
-  *          @arg @ref HAL_ETH_DMA_ERROR_CB_ID   DMA Error Callback ID
+  *          @arg @ref HAL_ETH_ERROR_CB_ID       Error Callback ID
+  *          @arg @ref HAL_ETH_PMT_CB_ID         Power Management Callback ID
+  *          @arg @ref HAL_ETH_WAKEUP_CB_ID      Wake UP Callback ID
   *          @arg @ref HAL_ETH_MSPINIT_CB_ID     MspInit callback ID
   *          @arg @ref HAL_ETH_MSPDEINIT_CB_ID   MspDeInit callback ID
   * @retval status
@@ -789,65 +596,74 @@ HAL_StatusTypeDef HAL_ETH_UnRegisterCallback(ETH_HandleTypeDef *heth, HAL_ETH_Ca
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  /* Process locked */
-  __HAL_LOCK(heth);
-
-  if(heth->State == HAL_ETH_STATE_READY)
+  if (heth->gState == HAL_ETH_STATE_READY)
   {
     switch (CallbackID)
     {
-    case HAL_ETH_TX_COMPLETE_CB_ID :
-      heth->TxCpltCallback = HAL_ETH_TxCpltCallback;
-      break;
+      case HAL_ETH_TX_COMPLETE_CB_ID :
+        heth->TxCpltCallback = HAL_ETH_TxCpltCallback;
+        break;
 
-    case HAL_ETH_RX_COMPLETE_CB_ID :
-      heth->RxCpltCallback = HAL_ETH_RxCpltCallback;
-      break;
+      case HAL_ETH_RX_COMPLETE_CB_ID :
+        heth->RxCpltCallback = HAL_ETH_RxCpltCallback;
+        break;
 
-    case HAL_ETH_DMA_ERROR_CB_ID :
-      heth->DMAErrorCallback = HAL_ETH_ErrorCallback;
-      break;
+      case HAL_ETH_ERROR_CB_ID :
+        heth->ErrorCallback = HAL_ETH_ErrorCallback;
+        break;
 
-    case HAL_ETH_MSPINIT_CB_ID :
-      heth->MspInitCallback = HAL_ETH_MspInit;
-      break;
+      case HAL_ETH_PMT_CB_ID :
+        heth->PMTCallback = HAL_ETH_PMTCallback;
+        break;
 
-    case HAL_ETH_MSPDEINIT_CB_ID :
-      heth->MspDeInitCallback = HAL_ETH_MspDeInit;
-      break;
 
-    default :
-      /* Return error status */
-      status =  HAL_ERROR;
-      break;
+      case HAL_ETH_WAKEUP_CB_ID :
+        heth->WakeUpCallback = HAL_ETH_WakeUpCallback;
+        break;
+
+      case HAL_ETH_MSPINIT_CB_ID :
+        heth->MspInitCallback = HAL_ETH_MspInit;
+        break;
+
+      case HAL_ETH_MSPDEINIT_CB_ID :
+        heth->MspDeInitCallback = HAL_ETH_MspDeInit;
+        break;
+
+      default :
+        /* Update the error code */
+        heth->ErrorCode |= HAL_ETH_ERROR_INVALID_CALLBACK;
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
     }
   }
-  else if(heth->State == HAL_ETH_STATE_RESET)
+  else if (heth->gState == HAL_ETH_STATE_RESET)
   {
     switch (CallbackID)
     {
-    case HAL_ETH_MSPINIT_CB_ID :
-      heth->MspInitCallback = HAL_ETH_MspInit;
-      break;
+      case HAL_ETH_MSPINIT_CB_ID :
+        heth->MspInitCallback = HAL_ETH_MspInit;
+        break;
 
-    case HAL_ETH_MSPDEINIT_CB_ID :
-      heth->MspDeInitCallback = HAL_ETH_MspDeInit;
-      break;
+      case HAL_ETH_MSPDEINIT_CB_ID :
+        heth->MspDeInitCallback = HAL_ETH_MspDeInit;
+        break;
 
-    default :
-      /* Return error status */
-      status =  HAL_ERROR;
-      break;
+      default :
+        /* Update the error code */
+        heth->ErrorCode |= HAL_ETH_ERROR_INVALID_CALLBACK;
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
     }
   }
   else
   {
+    /* Update the error code */
+    heth->ErrorCode |= HAL_ETH_ERROR_INVALID_CALLBACK;
     /* Return error status */
     status =  HAL_ERROR;
   }
-
-  /* Release Lock */
-  __HAL_UNLOCK(heth);
 
   return status;
 }
@@ -857,385 +673,1256 @@ HAL_StatusTypeDef HAL_ETH_UnRegisterCallback(ETH_HandleTypeDef *heth, HAL_ETH_Ca
   * @}
   */
 
-/** @defgroup ETH_Exported_Functions_Group2 IO operation functions 
-  *  @brief   Data transfers functions 
+/** @defgroup ETH_Exported_Functions_Group2 IO operation functions
+  *  @brief ETH Transmit and Receive functions
   *
-  @verbatim   
+@verbatim
   ==============================================================================
-                          ##### IO operation functions #####
-  ==============================================================================  
-  [..]  This section provides functions allowing to:
-        (+) Transmit a frame
-            HAL_ETH_TransmitFrame();
-        (+) Receive a frame
-            HAL_ETH_GetReceivedFrame();
-            HAL_ETH_GetReceivedFrame_IT();
-        (+) Read from an External PHY register
-            HAL_ETH_ReadPHYRegister();
-        (+) Write to an External PHY register
-            HAL_ETH_WritePHYRegister();
+                      ##### IO operation functions #####
+  ==============================================================================
+  [..]
+    This subsection provides a set of functions allowing to manage the ETH
+    data transfer.
 
-  @endverbatim
-  
+@endverbatim
   * @{
   */
 
 /**
-  * @brief  Sends an Ethernet frame. 
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
+  * @brief  Enables Ethernet MAC and DMA reception and transmission
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
   *         the configuration information for ETHERNET module
-  * @param  FrameLength Amount of data to be sent
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ETH_TransmitFrame(ETH_HandleTypeDef *heth, uint32_t FrameLength)
+HAL_StatusTypeDef HAL_ETH_Start(ETH_HandleTypeDef *heth)
 {
-  uint32_t bufcount = 0, size = 0, i = 0;
-  
-  /* Process Locked */
-  __HAL_LOCK(heth);
-  
-  /* Set the ETH peripheral state to BUSY */
-  heth->State = HAL_ETH_STATE_BUSY;
-  
-  if (FrameLength == 0) 
+  if (heth->gState == HAL_ETH_STATE_READY)
   {
-    /* Set ETH HAL state to READY */
-    heth->State = HAL_ETH_STATE_READY;
-    
-    /* Process Unlocked */
-    __HAL_UNLOCK(heth);
-    
-    return  HAL_ERROR;                                    
-  }  
-  
-  /* Check if the descriptor is owned by the ETHERNET DMA (when set) or CPU (when reset) */
-  if(((heth->TxDesc)->Status & ETH_DMATXDESC_OWN) != (uint32_t)RESET)
-  {  
-    /* OWN bit set */
-    heth->State = HAL_ETH_STATE_BUSY_TX;
-    
-    /* Process Unlocked */
-    __HAL_UNLOCK(heth);
-    
-    return HAL_ERROR;
-  }
-  
-  /* Get the number of needed Tx buffers for the current frame */
-  if (FrameLength > ETH_TX_BUF_SIZE)
-  {
-    bufcount = FrameLength/ETH_TX_BUF_SIZE;
-    if (FrameLength % ETH_TX_BUF_SIZE) 
-    {
-      bufcount++;
-    }
-  }
-  else 
-  {  
-    bufcount = 1;
-  }
-  if (bufcount == 1)
-  {
-    /* Set LAST and FIRST segment */
-    heth->TxDesc->Status |=ETH_DMATXDESC_FS|ETH_DMATXDESC_LS;
-    /* Set frame size */
-    heth->TxDesc->ControlBufferSize = (FrameLength & ETH_DMATXDESC_TBS1);
-    /* Set Own bit of the Tx descriptor Status: gives the buffer back to ETHERNET DMA */
-    heth->TxDesc->Status |= ETH_DMATXDESC_OWN;
-    /* Point to next descriptor */
-    heth->TxDesc= (ETH_DMADescTypeDef *)(heth->TxDesc->Buffer2NextDescAddr);
+    heth->gState = HAL_ETH_STATE_BUSY;
+
+    /* Set nombre of descriptors to build */
+    heth->RxDescList.RxBuildDescCnt = ETH_RX_DESC_CNT;
+
+    /* Build all descriptors */
+    ETH_UpdateDescriptor(heth);
+
+    /* Enable the MAC transmission */
+    SET_BIT(heth->Instance->MACCR, ETH_MACCR_TE);
+
+    /* Enable the MAC reception */
+    SET_BIT(heth->Instance->MACCR, ETH_MACCR_RE);
+
+    /* Flush Transmit FIFO */
+    ETH_FlushTransmitFIFO(heth);
+
+    /* Enable the DMA transmission */
+    SET_BIT(heth->Instance->DMAOMR, ETH_DMAOMR_ST);
+
+    /* Enable the DMA reception */
+    SET_BIT(heth->Instance->DMAOMR, ETH_DMAOMR_SR);
+
+    heth->gState = HAL_ETH_STATE_STARTED;
+
+    return HAL_OK;
   }
   else
   {
-    for (i=0; i< bufcount; i++)
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Enables Ethernet MAC and DMA reception/transmission in Interrupt mode
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_Start_IT(ETH_HandleTypeDef *heth)
+{
+  if (heth->gState == HAL_ETH_STATE_READY)
+  {
+    heth->gState = HAL_ETH_STATE_BUSY;
+
+    /* save IT mode to ETH Handle */
+    heth->RxDescList.ItMode = 1U;
+    /* Disable MMC Interrupts */
+    SET_BIT(heth->Instance->MACIMR, ETH_MACIMR_TSTIM | ETH_MACIMR_PMTIM);
+
+    /* Disable Rx MMC Interrupts */
+    SET_BIT(heth->Instance->MMCRIMR, ETH_MMCRIMR_RGUFM | ETH_MMCRIMR_RFAEM | \
+            ETH_MMCRIMR_RFCEM);
+
+    /* Disable Tx MMC Interrupts */
+    SET_BIT(heth->Instance->MMCTIMR, ETH_MMCTIMR_TGFM | ETH_MMCTIMR_TGFMSCM | \
+            ETH_MMCTIMR_TGFSCM);
+
+    /* Set nombre of descriptors to build */
+    heth->RxDescList.RxBuildDescCnt = ETH_RX_DESC_CNT;
+
+    /* Build all descriptors */
+    ETH_UpdateDescriptor(heth);
+
+    /* Enable the MAC transmission */
+    SET_BIT(heth->Instance->MACCR, ETH_MACCR_TE);
+
+    /* Enable the MAC reception */
+    SET_BIT(heth->Instance->MACCR, ETH_MACCR_RE);
+
+    /* Flush Transmit FIFO */
+    ETH_FlushTransmitFIFO(heth);
+
+    /* Enable the DMA transmission */
+    SET_BIT(heth->Instance->DMAOMR, ETH_DMAOMR_ST);
+
+    /* Enable the DMA reception */
+    SET_BIT(heth->Instance->DMAOMR, ETH_DMAOMR_SR);
+
+    /* Enable ETH DMA interrupts:
+    - Tx complete interrupt
+    - Rx complete interrupt
+    - Fatal bus interrupt
+    */
+    __HAL_ETH_DMA_ENABLE_IT(heth, (ETH_DMAIER_NISE | ETH_DMAIER_RIE | ETH_DMAIER_TIE  |
+                                   ETH_DMAIER_FBEIE | ETH_DMAIER_AISE | ETH_DMAIER_RBUIE));
+
+    heth->gState = HAL_ETH_STATE_STARTED;
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Stop Ethernet MAC and DMA reception/transmission
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_Stop(ETH_HandleTypeDef *heth)
+{
+  if (heth->gState == HAL_ETH_STATE_STARTED)
+  {
+    /* Set the ETH peripheral state to BUSY */
+    heth->gState = HAL_ETH_STATE_BUSY;
+    /* Disable the DMA transmission */
+    CLEAR_BIT(heth->Instance->MACCR, ETH_MACCR_TE);
+
+    /* Disable the DMA reception */
+    CLEAR_BIT(heth->Instance->DMAOMR, ETH_DMAOMR_SR);
+
+    /* Disable the MAC reception */
+    CLEAR_BIT(heth->Instance->MACCR, ETH_MACCR_RE);
+
+    /* Flush Transmit FIFO */
+    ETH_FlushTransmitFIFO(heth);
+
+    /* Disable the MAC transmission */
+    CLEAR_BIT(heth->Instance->MACCR, ETH_MACCR_TE);
+
+    heth->gState = HAL_ETH_STATE_READY;
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Stop Ethernet MAC and DMA reception/transmission in Interrupt mode
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_Stop_IT(ETH_HandleTypeDef *heth)
+{
+  ETH_DMADescTypeDef *dmarxdesc;
+  uint32_t descindex;
+
+  if (heth->gState == HAL_ETH_STATE_STARTED)
+  {
+    /* Set the ETH peripheral state to BUSY */
+    heth->gState = HAL_ETH_STATE_BUSY;
+
+    __HAL_ETH_DMA_DISABLE_IT(heth, (ETH_DMAIER_NISE | ETH_DMAIER_RIE | ETH_DMAIER_TIE  |
+                                    ETH_DMAIER_FBEIE | ETH_DMAIER_AISE | ETH_DMAIER_RBUIE));
+
+    /* Disable the DMA transmission */
+    CLEAR_BIT(heth->Instance->MACCR, ETH_MACCR_TE);
+
+    /* Disable the DMA reception */
+    CLEAR_BIT(heth->Instance->DMAOMR, ETH_DMAOMR_SR);
+
+    /* Disable the MAC reception */
+    CLEAR_BIT(heth->Instance->MACCR, ETH_MACCR_RE);
+    /* Flush Transmit FIFO */
+    ETH_FlushTransmitFIFO(heth);
+
+    /* Disable the MAC transmission */
+    CLEAR_BIT(heth->Instance->MACCR, ETH_MACCR_TE);
+
+    /* Clear IOC bit to all Rx descriptors */
+    for (descindex = 0; descindex < (uint32_t)ETH_RX_DESC_CNT; descindex++)
     {
-      /* Clear FIRST and LAST segment bits */
-      heth->TxDesc->Status &= ~(ETH_DMATXDESC_FS | ETH_DMATXDESC_LS);
-      
-      if (i == 0) 
+      dmarxdesc = (ETH_DMADescTypeDef *)heth->RxDescList.RxDesc[descindex];
+      SET_BIT(dmarxdesc->DESC1, ETH_DMARXDESC_DIC);
+    }
+
+    heth->RxDescList.ItMode = 0U;
+
+    heth->gState = HAL_ETH_STATE_READY;
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Sends an Ethernet Packet in polling mode.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  pTxConfig: Hold the configuration of packet to be transmitted
+  * @param  Timeout: timeout value
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_Transmit(ETH_HandleTypeDef *heth, ETH_TxPacketConfig *pTxConfig, uint32_t Timeout)
+{
+  uint32_t tickstart;
+  ETH_DMADescTypeDef *dmatxdesc;
+
+  if (pTxConfig == NULL)
+  {
+    heth->ErrorCode |= HAL_ETH_ERROR_PARAM;
+    return HAL_ERROR;
+  }
+
+  if (heth->gState == HAL_ETH_STATE_STARTED)
+  {
+    /* Config DMA Tx descriptor by Tx Packet info */
+    if (ETH_Prepare_Tx_Descriptors(heth, pTxConfig, 0) != HAL_ETH_ERROR_NONE)
+    {
+      /* Set the ETH error code */
+      heth->ErrorCode |= HAL_ETH_ERROR_BUSY;
+      return HAL_ERROR;
+    }
+
+    /* Ensure completion of descriptor preparation before transmission start */
+    __DSB();
+
+    dmatxdesc = (ETH_DMADescTypeDef *)(&heth->TxDescList)->TxDesc[heth->TxDescList.CurTxDesc];
+
+    /* Incr current tx desc index */
+    INCR_TX_DESC_INDEX(heth->TxDescList.CurTxDesc, 1U);
+
+    /* Start transmission */
+    /* issue a poll command to Tx DMA by writing address of next immediate free descriptor */
+    WRITE_REG(heth->Instance->DMATPDR, (uint32_t)(heth->TxDescList.TxDesc[heth->TxDescList.CurTxDesc]));
+
+    tickstart = HAL_GetTick();
+
+    /* Wait for data to be transmitted or timeout occurred */
+    while ((dmatxdesc->DESC0 & ETH_DMATXDESC_OWN) != (uint32_t)RESET)
+    {
+      if ((heth->Instance->DMASR & ETH_DMASR_FBES) != (uint32_t)RESET)
       {
-        /* Setting the first segment bit */
-        heth->TxDesc->Status |= ETH_DMATXDESC_FS;  
+        heth->ErrorCode |= HAL_ETH_ERROR_DMA;
+        heth->DMAErrorCode = heth->Instance->DMASR;
+        /* Return function status */
+        return HAL_ERROR;
       }
-      
-      /* Program size */
-      heth->TxDesc->ControlBufferSize = (ETH_TX_BUF_SIZE & ETH_DMATXDESC_TBS1);
-      
-      if (i == (bufcount-1))
+
+      /* Check for the Timeout */
+      if (Timeout != HAL_MAX_DELAY)
       {
-        /* Setting the last segment bit */
-        heth->TxDesc->Status |= ETH_DMATXDESC_LS;
-        size = FrameLength - (bufcount-1)*ETH_TX_BUF_SIZE;
-        heth->TxDesc->ControlBufferSize = (size & ETH_DMATXDESC_TBS1);
+        if (((HAL_GetTick() - tickstart) > Timeout) || (Timeout == 0U))
+        {
+          heth->ErrorCode |= HAL_ETH_ERROR_TIMEOUT;
+          /* Clear TX descriptor so that we can proceed */
+          dmatxdesc->DESC0 = (ETH_DMATXDESC_FS | ETH_DMATXDESC_LS);
+          return HAL_ERROR;
+        }
       }
-      
-      /* Set Own bit of the Tx descriptor Status: gives the buffer back to ETHERNET DMA */
-      heth->TxDesc->Status |= ETH_DMATXDESC_OWN;
-      /* point to next descriptor */
-      heth->TxDesc = (ETH_DMADescTypeDef *)(heth->TxDesc->Buffer2NextDescAddr);
+    }
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Sends an Ethernet Packet in interrupt mode.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  pTxConfig: Hold the configuration of packet to be transmitted
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_Transmit_IT(ETH_HandleTypeDef *heth, ETH_TxPacketConfig *pTxConfig)
+{
+  if (pTxConfig == NULL)
+  {
+    heth->ErrorCode |= HAL_ETH_ERROR_PARAM;
+    return HAL_ERROR;
+  }
+
+  if (heth->gState == HAL_ETH_STATE_STARTED)
+  {
+    /* Save the packet pointer to release.  */
+    heth->TxDescList.CurrentPacketAddress = (uint32_t *)pTxConfig->pData;
+
+    /* Config DMA Tx descriptor by Tx Packet info */
+    if (ETH_Prepare_Tx_Descriptors(heth, pTxConfig, 1) != HAL_ETH_ERROR_NONE)
+    {
+      heth->ErrorCode |= HAL_ETH_ERROR_BUSY;
+      return HAL_ERROR;
+    }
+
+    /* Ensure completion of descriptor preparation before transmission start */
+    __DSB();
+
+    /* Incr current tx desc index */
+    INCR_TX_DESC_INDEX(heth->TxDescList.CurTxDesc, 1U);
+
+    /* Start transmission */
+    /* issue a poll command to Tx DMA by writing address of next immediate free descriptor */
+    if (((heth->Instance)->DMASR & ETH_DMASR_TBUS) != (uint32_t)RESET)
+    {
+      /* Clear TBUS ETHERNET DMA flag */
+      (heth->Instance)->DMASR = ETH_DMASR_TBUS;
+      /* Resume DMA transmission*/
+      (heth->Instance)->DMATPDR = 0U;
+    }
+
+    return HAL_OK;
+
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Read a received packet.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  pAppBuff: Pointer to an application buffer to receive the packet.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_ReadData(ETH_HandleTypeDef *heth, void **pAppBuff)
+{
+  uint32_t descidx;
+  ETH_DMADescTypeDef *dmarxdesc;
+  uint32_t desccnt = 0U;
+  uint32_t desccntmax;
+  uint32_t bufflength;
+  uint8_t rxdataready = 0U;
+
+
+  if (pAppBuff == NULL)
+  {
+    heth->ErrorCode |= HAL_ETH_ERROR_PARAM;
+    return HAL_ERROR;
+  }
+
+  if (heth->gState != HAL_ETH_STATE_STARTED)
+  {
+    return HAL_ERROR;
+  }
+
+  descidx = heth->RxDescList.RxDescIdx;
+  dmarxdesc = (ETH_DMADescTypeDef *)heth->RxDescList.RxDesc[descidx];
+  desccntmax = ETH_RX_DESC_CNT - heth->RxDescList.RxBuildDescCnt;
+
+  /* Check if descriptor is not owned by DMA */
+  while ((READ_BIT(dmarxdesc->DESC0, ETH_DMARXDESC_OWN) == (uint32_t)RESET) && (desccnt < desccntmax)
+         && (rxdataready == 0U))
+  {
+    if (READ_BIT(dmarxdesc->DESC0,  ETH_DMARXDESC_LS)  != (uint32_t)RESET)
+    {
+      /* Get timestamp high */
+      heth->RxDescList.TimeStamp.TimeStampHigh = dmarxdesc->DESC6;
+      /* Get timestamp low */
+      heth->RxDescList.TimeStamp.TimeStampLow  = dmarxdesc->DESC7;
+    }
+    if ((READ_BIT(dmarxdesc->DESC0, ETH_DMARXDESC_FS) != (uint32_t)RESET) || (heth->RxDescList.pRxStart != NULL))
+    {
+      /* Check first descriptor */
+      if (READ_BIT(dmarxdesc->DESC0, ETH_DMARXDESC_FS) != (uint32_t)RESET)
+      {
+        heth->RxDescList.RxDescCnt = 0;
+        heth->RxDescList.RxDataLength = 0;
+      }
+
+      /* Check if last descriptor */
+      bufflength = heth->Init.RxBuffLen;
+      if (READ_BIT(dmarxdesc->DESC0, ETH_DMARXDESC_LS) != (uint32_t)RESET)
+      {
+        /* Get the Frame Length of the received packet: substruct 4 bytes of the CRC */
+        bufflength = ((dmarxdesc->DESC0 & ETH_DMARXDESC_FL) >> ETH_DMARXDESC_FRAMELENGTHSHIFT) - 4U;
+
+        /* Save Last descriptor index */
+        heth->RxDescList.pRxLastRxDesc = dmarxdesc->DESC0;
+
+        /* Packet ready */
+        rxdataready = 1;
+      }
+
+      /* Link data */
+      WRITE_REG(dmarxdesc->BackupAddr0, dmarxdesc->DESC2);
+#if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
+      /*Call registered Link callback*/
+      heth->rxLinkCallback(&heth->RxDescList.pRxStart, &heth->RxDescList.pRxEnd,
+                           (uint8_t *)dmarxdesc->BackupAddr0, bufflength);
+#else
+      /* Link callback */
+      HAL_ETH_RxLinkCallback(&heth->RxDescList.pRxStart, &heth->RxDescList.pRxEnd,
+                             (uint8_t *)dmarxdesc->BackupAddr0, (uint16_t) bufflength);
+#endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */
+      heth->RxDescList.RxDescCnt++;
+      heth->RxDescList.RxDataLength += bufflength;
+
+      /* Clear buffer pointer */
+      dmarxdesc->BackupAddr0 = 0;
+    }
+
+    /* Increment current rx descriptor index */
+    INCR_RX_DESC_INDEX(descidx, 1U);
+    /* Get current descriptor address */
+    dmarxdesc = (ETH_DMADescTypeDef *)heth->RxDescList.RxDesc[descidx];
+    desccnt++;
+  }
+
+  heth->RxDescList.RxBuildDescCnt += desccnt;
+  if ((heth->RxDescList.RxBuildDescCnt) != 0U)
+  {
+    /* Update Descriptors */
+    ETH_UpdateDescriptor(heth);
+  }
+
+  heth->RxDescList.RxDescIdx = descidx;
+
+  if (rxdataready == 1U)
+  {
+    /* Return received packet */
+    *pAppBuff = heth->RxDescList.pRxStart;
+    /* Reset first element */
+    heth->RxDescList.pRxStart = NULL;
+
+    return HAL_OK;
+  }
+
+  /* Packet not ready */
+  return HAL_ERROR;
+}
+
+/**
+  * @brief  This function gives back Rx Desc of the last received Packet
+  *         to the DMA, so ETH DMA will be able to use these descriptors
+  *         to receive next Packets.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval HAL status
+  */
+static void ETH_UpdateDescriptor(ETH_HandleTypeDef *heth)
+{
+  uint32_t descidx;
+  uint32_t desccount;
+  ETH_DMADescTypeDef *dmarxdesc;
+  uint8_t *buff = NULL;
+  uint8_t allocStatus = 1U;
+
+  descidx = heth->RxDescList.RxBuildDescIdx;
+  dmarxdesc = (ETH_DMADescTypeDef *)heth->RxDescList.RxDesc[descidx];
+  desccount = heth->RxDescList.RxBuildDescCnt;
+
+  while ((desccount > 0U) && (allocStatus != 0U))
+  {
+    /* Check if a buffer's attached the descriptor */
+    if (READ_REG(dmarxdesc->BackupAddr0) == 0U)
+    {
+      /* Get a new buffer. */
+#if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
+      /*Call registered Allocate callback*/
+      heth->rxAllocateCallback(&buff);
+#else
+      /* Allocate callback */
+      HAL_ETH_RxAllocateCallback(&buff);
+#endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */
+      if (buff == NULL)
+      {
+        allocStatus = 0U;
+      }
+      else
+      {
+        WRITE_REG(dmarxdesc->BackupAddr0, (uint32_t)buff);
+        WRITE_REG(dmarxdesc->DESC2, (uint32_t)buff);
+      }
+    }
+
+    if (allocStatus != 0U)
+    {
+      /* Ensure rest of descriptor is written to RAM before the OWN bit */
+      __DMB();
+
+      WRITE_REG(dmarxdesc->DESC0, ETH_DMARXDESC_OWN);
+
+      if (heth->RxDescList.ItMode == 0U)
+      {
+        WRITE_REG(dmarxdesc->DESC1, ETH_DMARXDESC_DIC | ETH_RX_BUF_SIZE | ETH_DMARXDESC_RCH);
+      }
+      else
+      {
+        WRITE_REG(dmarxdesc->DESC1, ETH_RX_BUF_SIZE | ETH_DMARXDESC_RCH);
+      }
+
+      /* Increment current rx descriptor index */
+      INCR_RX_DESC_INDEX(descidx, 1U);
+      /* Get current descriptor address */
+      dmarxdesc = (ETH_DMADescTypeDef *)heth->RxDescList.RxDesc[descidx];
+      desccount--;
     }
   }
-  
-  /* When Tx Buffer unavailable flag is set: clear it and resume transmission */
-  if (((heth->Instance)->DMASR & ETH_DMASR_TBUS) != (uint32_t)RESET)
+
+  if (heth->RxDescList.RxBuildDescCnt != desccount)
   {
-    /* Clear TBUS ETHERNET DMA flag */
-    (heth->Instance)->DMASR = ETH_DMASR_TBUS;
-    /* Resume DMA transmission*/
-    (heth->Instance)->DMATPDR = 0;
+    /* Set the Tail pointer address */
+    WRITE_REG(heth->Instance->DMARPDR, 0);
+
+    heth->RxDescList.RxBuildDescIdx = descidx;
+    heth->RxDescList.RxBuildDescCnt = desccount;
   }
-  
-  /* Set ETH HAL State to Ready */
-  heth->State = HAL_ETH_STATE_READY;
-  
-  /* Process Unlocked */
-  __HAL_UNLOCK(heth);
-  
+}
+
+/**
+  * @brief  Register the Rx alloc callback.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  rxAllocateCallback: pointer to function to alloc buffer
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_RegisterRxAllocateCallback(ETH_HandleTypeDef *heth,
+                                                     pETH_rxAllocateCallbackTypeDef rxAllocateCallback)
+{
+  if (rxAllocateCallback == NULL)
+  {
+    /* No buffer to save */
+    return HAL_ERROR;
+  }
+
+  /* Set function to allocate buffer */
+  heth->rxAllocateCallback = rxAllocateCallback;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Unregister the Rx alloc callback.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_UnRegisterRxAllocateCallback(ETH_HandleTypeDef *heth)
+{
+  /* Set function to allocate buffer */
+  heth->rxAllocateCallback = HAL_ETH_RxAllocateCallback;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Rx Allocate callback.
+  * @param  buff: pointer to allocated buffer
+  * @retval None
+  */
+__weak void HAL_ETH_RxAllocateCallback(uint8_t **buff)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(buff);
+  /* NOTE : This function Should not be modified, when the callback is needed,
+  the HAL_ETH_RxAllocateCallback could be implemented in the user file
+  */
+}
+
+/**
+  * @brief  Rx Link callback.
+  * @param  pStart: pointer to packet start
+  * @param  pStart: pointer to packet end
+  * @param  buff: pointer to received data
+  * @param  Length: received data length
+  * @retval None
+  */
+__weak void HAL_ETH_RxLinkCallback(void **pStart, void **pEnd, uint8_t *buff, uint16_t Length)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(pStart);
+  UNUSED(pEnd);
+  UNUSED(buff);
+  UNUSED(Length);
+  /* NOTE : This function Should not be modified, when the callback is needed,
+  the HAL_ETH_RxLinkCallback could be implemented in the user file
+  */
+}
+
+/**
+  * @brief  Set the Rx link data function.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  rxLinkCallback: pointer to function to link data
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_RegisterRxLinkCallback(ETH_HandleTypeDef *heth, pETH_rxLinkCallbackTypeDef rxLinkCallback)
+{
+  if (rxLinkCallback == NULL)
+  {
+    /* No buffer to save */
+    return HAL_ERROR;
+  }
+
+  /* Set function to link data */
+  heth->rxLinkCallback = rxLinkCallback;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Unregister the Rx link callback.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_UnRegisterRxLinkCallback(ETH_HandleTypeDef *heth)
+{
+  /* Set function to allocate buffer */
+  heth->rxLinkCallback = HAL_ETH_RxLinkCallback;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Get the error state of the last received packet.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  pErrorCode: pointer to uint32_t to hold the error code
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_GetRxDataErrorCode(ETH_HandleTypeDef *heth, uint32_t *pErrorCode)
+{
+  /* Get error bits. */
+  *pErrorCode = READ_BIT(heth->RxDescList.pRxLastRxDesc, ETH_DMARXDESC_ERRORS_MASK);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set the Tx free function.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  txFreeCallback: pointer to function to release the packet
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_RegisterTxFreeCallback(ETH_HandleTypeDef *heth, pETH_txFreeCallbackTypeDef txFreeCallback)
+{
+  if (txFreeCallback == NULL)
+  {
+    /* No buffer to save */
+    return HAL_ERROR;
+  }
+
+  /* Set function to free transmmitted packet */
+  heth->txFreeCallback = txFreeCallback;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Unregister the Tx free callback.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_UnRegisterTxFreeCallback(ETH_HandleTypeDef *heth)
+{
+  /* Set function to allocate buffer */
+  heth->txFreeCallback = HAL_ETH_TxFreeCallback;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Tx Free callback.
+  * @param  buff: pointer to buffer to free
+  * @retval None
+  */
+__weak void HAL_ETH_TxFreeCallback(uint32_t *buff)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(buff);
+  /* NOTE : This function Should not be modified, when the callback is needed,
+  the HAL_ETH_TxFreeCallback could be implemented in the user file
+  */
+}
+
+/**
+  * @brief  Release transmitted Tx packets.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_ReleaseTxPacket(ETH_HandleTypeDef *heth)
+{
+  ETH_TxDescListTypeDef *dmatxdesclist = &heth->TxDescList;
+  uint32_t numOfBuf =  dmatxdesclist->BuffersInUse;
+  uint32_t idx =       dmatxdesclist->releaseIndex;
+  uint8_t pktTxStatus = 1U;
+  uint8_t pktInUse;
+#ifdef HAL_ETH_USE_PTP
+  ETH_TimeStampTypeDef *timestamp = &heth->TxTimestamp;
+#endif /* HAL_ETH_USE_PTP */
+
+  /* Loop through buffers in use.  */
+  while ((numOfBuf != 0U) && (pktTxStatus != 0U))
+  {
+    pktInUse = 1U;
+    numOfBuf--;
+    /* If no packet, just examine the next packet.  */
+    if (dmatxdesclist->PacketAddress[idx] == NULL)
+    {
+      /* No packet in use, skip to next.  */
+      idx = (idx + 1U) & (ETH_TX_DESC_CNT - 1U);
+      pktInUse = 0U;
+    }
+
+    if (pktInUse != 0U)
+    {
+      /* Determine if the packet has been transmitted.  */
+      if ((heth->Init.TxDesc[idx].DESC0 & ETH_DMATXDESC_OWN) == 0U)
+      {
+#ifdef HAL_ETH_USE_PTP
+        /* Get timestamp low */
+        timestamp->TimeStampLow = heth->Init.TxDesc[idx].DESC6;
+        /* Get timestamp high */
+        timestamp->TimeStampHigh = heth->Init.TxDesc[idx].DESC7;
+#endif /* HAL_ETH_USE_PTP */
+
+#if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
+        /*Call registered callbacks*/
+#ifdef HAL_ETH_USE_PTP
+        /* Handle Ptp  */
+        heth->txPtpCallback(dmatxdesclist->PacketAddress[idx], timestamp);
+#endif  /* HAL_ETH_USE_PTP */
+        /* Release the packet.  */
+        heth->txFreeCallback(dmatxdesclist->PacketAddress[idx]);
+#else
+        /* Call callbacks */
+#ifdef HAL_ETH_USE_PTP
+        /* Handle Ptp  */
+        HAL_ETH_TxPtpCallback(dmatxdesclist->PacketAddress[idx], timestamp);
+#endif  /* HAL_ETH_USE_PTP */
+        /* Release the packet.  */
+        HAL_ETH_TxFreeCallback(dmatxdesclist->PacketAddress[idx]);
+#endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */
+
+        /* Clear the entry in the in-use array.  */
+        dmatxdesclist->PacketAddress[idx] = NULL;
+
+        /* Update the transmit relesae index and number of buffers in use.  */
+        idx = (idx + 1U) & (ETH_TX_DESC_CNT - 1U);
+        dmatxdesclist->BuffersInUse = numOfBuf;
+        dmatxdesclist->releaseIndex = idx;
+      }
+      else
+      {
+        /* Get out of the loop!  */
+        pktTxStatus = 0U;
+      }
+    }
+  }
+  return HAL_OK;
+}
+
+#ifdef HAL_ETH_USE_PTP
+/**
+  * @brief  Set the Ethernet PTP configuration.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  ptpconfig: pointer to a ETH_PTP_ConfigTypeDef structure that contains
+  *         the configuration information for PTP
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_PTP_SetConfig(ETH_HandleTypeDef *heth, ETH_PTP_ConfigTypeDef *ptpconfig)
+{
+  uint32_t tmpTSCR;
+  ETH_TimeTypeDef time;
+
+  if (ptpconfig == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  tmpTSCR = ptpconfig->Timestamp |
+            ((uint32_t)ptpconfig->TimestampUpdate << ETH_PTPTSCR_TSFCU_Pos) |
+            ((uint32_t)ptpconfig->TimestampAll << ETH_PTPTSCR_TSSARFE_Pos) |
+            ((uint32_t)ptpconfig->TimestampRolloverMode << ETH_PTPTSCR_TSSSR_Pos) |
+            ((uint32_t)ptpconfig->TimestampV2 << ETH_PTPTSCR_TSPTPPSV2E_Pos) |
+            ((uint32_t)ptpconfig->TimestampEthernet << ETH_PTPTSCR_TSSPTPOEFE_Pos) |
+            ((uint32_t)ptpconfig->TimestampIPv6 << ETH_PTPTSCR_TSSIPV6FE_Pos) |
+            ((uint32_t)ptpconfig->TimestampIPv4 << ETH_PTPTSCR_TSSIPV4FE_Pos) |
+            ((uint32_t)ptpconfig->TimestampEvent << ETH_PTPTSCR_TSSEME_Pos) |
+            ((uint32_t)ptpconfig->TimestampMaster << ETH_PTPTSCR_TSSMRME_Pos) |
+            ((uint32_t)ptpconfig->TimestampFilter << ETH_PTPTSCR_TSPFFMAE_Pos) |
+            ((uint32_t)ptpconfig->TimestampClockType << ETH_PTPTSCR_TSCNT_Pos);
+
+  /* Write to MACTSCR */
+  MODIFY_REG(heth->Instance->PTPTSCR, ETH_MACTSCR_MASK, tmpTSCR);
+
+  /* Enable Timestamp */
+  SET_BIT(heth->Instance->PTPTSCR, ETH_PTPTSCR_TSE);
+  WRITE_REG(heth->Instance->PTPSSIR, ptpconfig->TimestampSubsecondInc);
+  WRITE_REG(heth->Instance->PTPTSAR, ptpconfig->TimestampAddend);
+
+  /* Enable Timestamp */
+  if (ptpconfig->TimestampAddendUpdate == ENABLE)
+  {
+    SET_BIT(heth->Instance->PTPTSCR, ETH_PTPTSCR_TSARU);
+    while ((heth->Instance->PTPTSCR & ETH_PTPTSCR_TSARU) != 0) {}
+  }
+
+  /* Enable Update mode */
+  if (ptpconfig->TimestampUpdateMode == ENABLE)
+  {
+    SET_BIT(heth->Instance->PTPTSCR, ETH_PTPTSCR_TSFCU);
+  }
+
+  /* Initialize Time */
+  time.Seconds = 0;
+  time.NanoSeconds = 0;
+  HAL_ETH_PTP_SetTime(heth, &time);
+
+  /* Ptp Init */
+  SET_BIT(heth->Instance->PTPTSCR, ETH_PTPTSCR_TSSTI);
+
+  /* Set PTP Configuration done */
+  heth->IsPtpConfigured = HAL_ETH_PTP_CONFIGURATED;
+
   /* Return function status */
   return HAL_OK;
 }
 
 /**
-  * @brief  Checks for received frames. 
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
+  * @brief  Get the Ethernet PTP configuration.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
   *         the configuration information for ETHERNET module
+  * @param  ptpconfig: pointer to a ETH_PTP_ConfigTypeDef structure that contains
+  *         the configuration information for PTP
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ETH_GetReceivedFrame(ETH_HandleTypeDef *heth)
+HAL_StatusTypeDef HAL_ETH_PTP_GetConfig(ETH_HandleTypeDef *heth, ETH_PTP_ConfigTypeDef *ptpconfig)
 {
-  uint32_t framelength = 0;
-  
-  /* Process Locked */
-  __HAL_LOCK(heth);
-  
-  /* Check the ETH state to BUSY */
-  heth->State = HAL_ETH_STATE_BUSY;
-  
-  /* Check if segment is not owned by DMA */
-  /* (((heth->RxDesc->Status & ETH_DMARXDESC_OWN) == (uint32_t)RESET) && ((heth->RxDesc->Status & ETH_DMARXDESC_LS) != (uint32_t)RESET)) */
-  if(((heth->RxDesc->Status & ETH_DMARXDESC_OWN) == (uint32_t)RESET))
+  if (ptpconfig == NULL)
   {
-    /* Check if last segment */
-    if(((heth->RxDesc->Status & ETH_DMARXDESC_LS) != (uint32_t)RESET)) 
-    {
-      /* increment segment count */
-      (heth->RxFrameInfos).SegCount++;
-      
-      /* Check if last segment is first segment: one segment contains the frame */
-      if ((heth->RxFrameInfos).SegCount == 1)
-      {
-        (heth->RxFrameInfos).FSRxDesc =heth->RxDesc;
-      }
-      
-      heth->RxFrameInfos.LSRxDesc = heth->RxDesc;
-      
-      /* Get the Frame Length of the received packet: substruct 4 bytes of the CRC */
-      framelength = (((heth->RxDesc)->Status & ETH_DMARXDESC_FL) >> ETH_DMARXDESC_FRAMELENGTHSHIFT) - 4;
-      heth->RxFrameInfos.length = framelength;
-      
-      /* Get the address of the buffer start address */
-      heth->RxFrameInfos.buffer = ((heth->RxFrameInfos).FSRxDesc)->Buffer1Addr;
-      /* point to next descriptor */
-      heth->RxDesc = (ETH_DMADescTypeDef*) ((heth->RxDesc)->Buffer2NextDescAddr);
-      
-      /* Set HAL State to Ready */
-      heth->State = HAL_ETH_STATE_READY;
-      
-      /* Process Unlocked */
-      __HAL_UNLOCK(heth);
-      
-      /* Return function status */
-      return HAL_OK;
-    }
-    /* Check if first segment */
-    else if((heth->RxDesc->Status & ETH_DMARXDESC_FS) != (uint32_t)RESET)
-    {
-      (heth->RxFrameInfos).FSRxDesc = heth->RxDesc;
-      (heth->RxFrameInfos).LSRxDesc = NULL;
-      (heth->RxFrameInfos).SegCount = 1;
-      /* Point to next descriptor */
-      heth->RxDesc = (ETH_DMADescTypeDef*) (heth->RxDesc->Buffer2NextDescAddr);
-    }
-    /* Check if intermediate segment */ 
-    else
-    {
-      (heth->RxFrameInfos).SegCount++;
-      /* Point to next descriptor */
-      heth->RxDesc = (ETH_DMADescTypeDef*) (heth->RxDesc->Buffer2NextDescAddr);
-    } 
+    return HAL_ERROR;
   }
-  
-  /* Set ETH HAL State to Ready */
-  heth->State = HAL_ETH_STATE_READY;
-  
-  /* Process Unlocked */
-  __HAL_UNLOCK(heth);
-  
+  ptpconfig->Timestamp = READ_BIT(heth->Instance->PTPTSCR, ETH_PTPTSCR_TSE);
+  ptpconfig->TimestampUpdate = ((READ_BIT(heth->Instance->PTPTSCR,
+                                          ETH_PTPTSCR_TSFCU) >> ETH_PTPTSCR_TSFCU_Pos) > 0U) ? ENABLE : DISABLE;
+  ptpconfig->TimestampAll = ((READ_BIT(heth->Instance->PTPTSCR,
+                                       ETH_PTPTSCR_TSSARFE) >> ETH_PTPTSCR_TSSARFE_Pos) > 0U) ? ENABLE : DISABLE;
+  ptpconfig->TimestampRolloverMode = ((READ_BIT(heth->Instance->PTPTSCR,
+                                                ETH_PTPTSCR_TSSSR) >> ETH_PTPTSCR_TSSSR_Pos) > 0U)
+                                     ? ENABLE : DISABLE;
+  ptpconfig->TimestampV2 = ((READ_BIT(heth->Instance->PTPTSCR,
+                                      ETH_PTPTSCR_TSPTPPSV2E) >> ETH_PTPTSCR_TSPTPPSV2E_Pos) > 0U) ? ENABLE : DISABLE;
+  ptpconfig->TimestampEthernet = ((READ_BIT(heth->Instance->PTPTSCR,
+                                            ETH_PTPTSCR_TSSPTPOEFE) >> ETH_PTPTSCR_TSSPTPOEFE_Pos) > 0U)
+                                 ? ENABLE : DISABLE;
+  ptpconfig->TimestampIPv6 = ((READ_BIT(heth->Instance->PTPTSCR,
+                                        ETH_PTPTSCR_TSSIPV6FE) >> ETH_PTPTSCR_TSSIPV6FE_Pos) > 0U) ? ENABLE : DISABLE;
+  ptpconfig->TimestampIPv4 = ((READ_BIT(heth->Instance->PTPTSCR,
+                                        ETH_PTPTSCR_TSSIPV4FE) >> ETH_PTPTSCR_TSSIPV4FE_Pos) > 0U) ? ENABLE : DISABLE;
+  ptpconfig->TimestampEvent = ((READ_BIT(heth->Instance->PTPTSCR,
+                                         ETH_PTPTSCR_TSSEME) >> ETH_PTPTSCR_TSSEME_Pos) > 0U) ? ENABLE : DISABLE;
+  ptpconfig->TimestampMaster = ((READ_BIT(heth->Instance->PTPTSCR,
+                                          ETH_PTPTSCR_TSSMRME) >> ETH_PTPTSCR_TSSMRME_Pos) > 0U) ? ENABLE : DISABLE;
+  ptpconfig->TimestampFilter = ((READ_BIT(heth->Instance->PTPTSCR,
+                                          ETH_PTPTSCR_TSPFFMAE) >> ETH_PTPTSCR_TSPFFMAE_Pos) > 0U) ? ENABLE : DISABLE;
+  ptpconfig->TimestampClockType = ((READ_BIT(heth->Instance->PTPTSCR,
+                                             ETH_PTPTSCR_TSCNT) >> ETH_PTPTSCR_TSCNT_Pos) > 0U) ? ENABLE : DISABLE;
+
   /* Return function status */
-  return HAL_ERROR;
+  return HAL_OK;
 }
 
 /**
-  * @brief  Gets the Received frame in interrupt mode. 
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
+  * @brief  Set Seconds and Nanoseconds for the Ethernet PTP registers.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  heth: pointer to a ETH_TimeTypeDef structure that contains
+  *         time to set
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_PTP_SetTime(ETH_HandleTypeDef *heth, ETH_TimeTypeDef *time)
+{
+  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURATED)
+  {
+    /* Set Seconds */
+    heth->Instance->PTPTSHUR = time->Seconds;
+
+    /* Set NanoSeconds */
+    heth->Instance->PTPTSLUR = time->NanoSeconds;
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Return function status */
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Get Seconds and Nanoseconds for the Ethernet PTP registers.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  heth: pointer to a ETH_TimeTypeDef structure that contains
+  *         time to get
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_PTP_GetTime(ETH_HandleTypeDef *heth, ETH_TimeTypeDef *time)
+{
+  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURATED)
+  {
+    /* Get Seconds */
+    time->Seconds = heth->Instance->PTPTSHR;
+
+    /* Get NanoSeconds */
+    time->NanoSeconds = heth->Instance->PTPTSLR;
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Return function status */
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Update time for the Ethernet PTP registers.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  timeupdate: pointer to a ETH_TIMEUPDATETypeDef structure that contains
+  *         the time update information
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_PTP_AddTimeOffset(ETH_HandleTypeDef *heth, ETH_PtpUpdateTypeDef ptpoffsettype,
+                                            ETH_TimeTypeDef *timeoffset)
+{
+  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURATED)
+  {
+    if (ptpoffsettype ==  HAL_ETH_PTP_NEGATIVE_UPDATE)
+    {
+      /* Set Seconds update */
+      heth->Instance->PTPTSHUR = ETH_PTPTSHR_VALUE - timeoffset->Seconds + 1U;
+
+      if (READ_BIT(heth->Instance->PTPTSCR, ETH_PTPTSCR_TSSSR) == ETH_PTPTSCR_TSSSR)
+      {
+        /* Set nanoSeconds update */
+        heth->Instance->PTPTSLUR = ETH_PTPTSLR_VALUE - timeoffset->NanoSeconds;
+      }
+      else
+      {
+        heth->Instance->PTPTSLUR = ETH_PTPTSHR_VALUE - timeoffset->NanoSeconds + 1U;
+      }
+    }
+    else
+    {
+      /* Set Seconds update */
+      heth->Instance->PTPTSHUR = timeoffset->Seconds;
+      /* Set nanoSeconds update */
+      heth->Instance->PTPTSLUR = timeoffset->NanoSeconds;
+    }
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Return function status */
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Insert Timestamp in transmission.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  txtimestampconf: Enable or Disable timestamp in transmission
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_PTP_InsertTxTimestamp(ETH_HandleTypeDef *heth)
+{
+  ETH_TxDescListTypeDef *dmatxdesclist = &heth->TxDescList;
+  uint32_t descidx = dmatxdesclist->CurTxDesc;
+  ETH_DMADescTypeDef *dmatxdesc = (ETH_DMADescTypeDef *)dmatxdesclist->TxDesc[descidx];
+
+  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURATED)
+  {
+    /* Enable Time Stamp transmission */
+    SET_BIT(dmatxdesc->DESC0, ETH_DMATXDESC_TTSE);
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Return function status */
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Get transmission timestamp.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  timestamp: pointer to ETH_TIMESTAMPTypeDef structure that contains
+  *         transmission timestamp
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_PTP_GetTxTimestamp(ETH_HandleTypeDef *heth, ETH_TimeStampTypeDef *timestamp)
+{
+  ETH_TxDescListTypeDef *dmatxdesclist = &heth->TxDescList;
+  uint32_t idx =       dmatxdesclist->releaseIndex;
+  ETH_DMADescTypeDef *dmatxdesc = (ETH_DMADescTypeDef *)dmatxdesclist->TxDesc[idx];
+
+  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURATED)
+  {
+    /* Get timestamp low */
+    timestamp->TimeStampLow = dmatxdesc->DESC0;
+    /* Get timestamp high */
+    timestamp->TimeStampHigh = dmatxdesc->DESC1;
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Return function status */
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Get receive timestamp.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  timestamp: pointer to ETH_TIMESTAMPTypeDef structure that contains
+  *         receive timestamp
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_PTP_GetRxTimestamp(ETH_HandleTypeDef *heth, ETH_TimeStampTypeDef *timestamp)
+{
+  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURATED)
+  {
+    /* Get timestamp low */
+    timestamp->TimeStampLow = heth->RxDescList.TimeStamp.TimeStampLow;
+    /* Get timestamp high */
+    timestamp->TimeStampHigh = heth->RxDescList.TimeStamp.TimeStampHigh;
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Return function status */
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Register the Tx Ptp callback.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  txPtpCallback: Function to handle Ptp transmission
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_RegisterTxPtpCallback(ETH_HandleTypeDef *heth, pETH_txPtpCallbackTypeDef txPtpCallback)
+{
+  if (txPtpCallback == NULL)
+  {
+    /* No buffer to save */
+    return HAL_ERROR;
+  }
+  /* Set Function to handle Tx Ptp */
+  heth->txPtpCallback = txPtpCallback;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Unregister the Tx Ptp callback.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
   *         the configuration information for ETHERNET module
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ETH_GetReceivedFrame_IT(ETH_HandleTypeDef *heth)
+HAL_StatusTypeDef HAL_ETH_UnRegisterTxPtpCallback(ETH_HandleTypeDef *heth)
 {
-  uint32_t descriptorscancounter = 0;
-  
-  /* Process Locked */
-  __HAL_LOCK(heth);
-  
-  /* Set ETH HAL State to BUSY */
-  heth->State = HAL_ETH_STATE_BUSY;
-  
-  /* Scan descriptors owned by CPU */
-  while (((heth->RxDesc->Status & ETH_DMARXDESC_OWN) == (uint32_t)RESET) && (descriptorscancounter < ETH_RXBUFNB))
-  {
-    /* Just for security */
-    descriptorscancounter++;
-    
-    /* Check if first segment in frame */
-    /* ((heth->RxDesc->Status & ETH_DMARXDESC_FS) != (uint32_t)RESET) && ((heth->RxDesc->Status & ETH_DMARXDESC_LS) == (uint32_t)RESET)) */  
-    if((heth->RxDesc->Status & (ETH_DMARXDESC_FS | ETH_DMARXDESC_LS)) == (uint32_t)ETH_DMARXDESC_FS)
-    { 
-      heth->RxFrameInfos.FSRxDesc = heth->RxDesc;
-      heth->RxFrameInfos.SegCount = 1;   
-      /* Point to next descriptor */
-      heth->RxDesc = (ETH_DMADescTypeDef*) (heth->RxDesc->Buffer2NextDescAddr);
-    }
-    /* Check if intermediate segment */
-    /* ((heth->RxDesc->Status & ETH_DMARXDESC_LS) == (uint32_t)RESET)&& ((heth->RxDesc->Status & ETH_DMARXDESC_FS) == (uint32_t)RESET)) */
-    else if ((heth->RxDesc->Status & (ETH_DMARXDESC_LS | ETH_DMARXDESC_FS)) == (uint32_t)RESET)
-    {
-      /* Increment segment count */
-      (heth->RxFrameInfos.SegCount)++;
-      /* Point to next descriptor */
-      heth->RxDesc = (ETH_DMADescTypeDef*)(heth->RxDesc->Buffer2NextDescAddr);
-    }
-    /* Should be last segment */
-    else
-    { 
-      /* Last segment */
-      heth->RxFrameInfos.LSRxDesc = heth->RxDesc;
-      
-      /* Increment segment count */
-      (heth->RxFrameInfos.SegCount)++;
-      
-      /* Check if last segment is first segment: one segment contains the frame */
-      if ((heth->RxFrameInfos.SegCount) == 1)
-      {
-        heth->RxFrameInfos.FSRxDesc = heth->RxDesc;
-      }
-      
-      /* Get the Frame Length of the received packet: substruct 4 bytes of the CRC */
-      heth->RxFrameInfos.length = (((heth->RxDesc)->Status & ETH_DMARXDESC_FL) >> ETH_DMARXDESC_FRAMELENGTHSHIFT) - 4;
-      
-      /* Get the address of the buffer start address */ 
-      heth->RxFrameInfos.buffer =((heth->RxFrameInfos).FSRxDesc)->Buffer1Addr;
-      
-      /* Point to next descriptor */      
-      heth->RxDesc = (ETH_DMADescTypeDef*) (heth->RxDesc->Buffer2NextDescAddr);
-      
-      /* Set HAL State to Ready */
-      heth->State = HAL_ETH_STATE_READY;
-      
-      /* Process Unlocked */
-      __HAL_UNLOCK(heth);
-  
-      /* Return function status */
-      return HAL_OK;
-    }
-  }
+  /* Set function to allocate buffer */
+  heth->txPtpCallback = HAL_ETH_TxPtpCallback;
 
-  /* Set HAL State to Ready */
-  heth->State = HAL_ETH_STATE_READY;
-  
-  /* Process Unlocked */
-  __HAL_UNLOCK(heth);
-  
-  /* Return function status */
-  return HAL_ERROR;
+  return HAL_OK;
 }
+
+/**
+  * @brief  Tx Ptp callback.
+  * @param  buff: pointer to application buffer
+  * @retval None
+  */
+__weak void HAL_ETH_TxPtpCallback(uint32_t *buff, ETH_TimeStampTypeDef *timestamp)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(buff);
+  /* NOTE : This function Should not be modified, when the callback is needed,
+  the HAL_ETH_TxPtpCallback could be implemented in the user file
+  */
+}
+#endif  /* HAL_ETH_USE_PTP */
 
 /**
   * @brief  This function handles ETH interrupt request.
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
   *         the configuration information for ETHERNET module
   * @retval HAL status
   */
 void HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth)
 {
-  /* Frame received */
-  if (__HAL_ETH_DMA_GET_FLAG(heth, ETH_DMA_FLAG_R)) 
+  /* Packet received */
+  if (__HAL_ETH_DMA_GET_IT(heth, ETH_DMASR_RS))
   {
+    if (__HAL_ETH_DMA_GET_IT_SOURCE(heth, ETH_DMAIER_RIE))
+    {
+      /* Clear the Eth DMA Rx IT pending bits */
+      __HAL_ETH_DMA_CLEAR_IT(heth, ETH_DMASR_RS | ETH_DMASR_NIS);
+
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
-    /*Call registered Receive complete callback*/
-    heth->RxCpltCallback(heth);
+      /*Call registered Receive complete callback*/
+      heth->RxCpltCallback(heth);
 #else
-    /* Receive complete callback */
-    HAL_ETH_RxCpltCallback(heth);
-#endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
-    
-     /* Clear the Eth DMA Rx IT pending bits */
-    __HAL_ETH_DMA_CLEAR_IT(heth, ETH_DMA_IT_R);
-
-    /* Set HAL State to Ready */
-    heth->State = HAL_ETH_STATE_READY;
-    
-    /* Process Unlocked */
-    __HAL_UNLOCK(heth);
-
+      /* Receive complete callback */
+      HAL_ETH_RxCpltCallback(heth);
+#endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */
+    }
   }
-  /* Frame transmitted */
-  else if (__HAL_ETH_DMA_GET_FLAG(heth, ETH_DMA_FLAG_T)) 
+
+  /* Packet transmitted */
+  if (__HAL_ETH_DMA_GET_IT(heth, ETH_DMASR_TS))
   {
-#if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
-    /*  Call resgistered Transfer complete callback*/
-    heth->TxCpltCallback(heth);
-#else
-    /* Transfer complete callback */
-    HAL_ETH_TxCpltCallback(heth);
-#endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
-    
-    /* Clear the Eth DMA Tx IT pending bits */
-    __HAL_ETH_DMA_CLEAR_IT(heth, ETH_DMA_IT_T);
+    if (__HAL_ETH_DMA_GET_IT_SOURCE(heth, ETH_DMAIER_TIE))
+    {
+      /* Clear the Eth DMA Tx IT pending bits */
+      __HAL_ETH_DMA_CLEAR_IT(heth, ETH_DMASR_TS | ETH_DMASR_NIS);
 
-    /* Set HAL State to Ready */
-    heth->State = HAL_ETH_STATE_READY;
-    
-    /* Process Unlocked */
-    __HAL_UNLOCK(heth);
+#if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
+      /*Call registered Transmit complete callback*/
+      heth->TxCpltCallback(heth);
+#else
+      /* Transfer complete callback */
+      HAL_ETH_TxCpltCallback(heth);
+#endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */
+    }
   }
-  
-  /* Clear the interrupt flags */
-  __HAL_ETH_DMA_CLEAR_IT(heth, ETH_DMA_IT_NIS);
-  
+
+
   /* ETH DMA Error */
-  if(__HAL_ETH_DMA_GET_FLAG(heth, ETH_DMA_FLAG_AIS))
+  if (__HAL_ETH_DMA_GET_IT(heth, ETH_DMASR_AIS))
   {
-#if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
-    heth->DMAErrorCallback(heth);
-#else
-    /* Ethernet Error callback */
-    HAL_ETH_ErrorCallback(heth);
-#endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
+    if (__HAL_ETH_DMA_GET_IT_SOURCE(heth, ETH_DMAIER_AISE))
+    {
+      heth->ErrorCode |= HAL_ETH_ERROR_DMA;
 
-    /* Clear the interrupt flags */
-    __HAL_ETH_DMA_CLEAR_IT(heth, ETH_DMA_FLAG_AIS);
-  
-    /* Set HAL State to Ready */
-    heth->State = HAL_ETH_STATE_READY;
-    
-    /* Process Unlocked */
-    __HAL_UNLOCK(heth);
+      /* if fatal bus error occurred */
+      if (__HAL_ETH_DMA_GET_IT(heth, ETH_DMASR_FBES))
+      {
+        /* Get DMA error code  */
+        heth->DMAErrorCode = READ_BIT(heth->Instance->DMASR, (ETH_DMASR_FBES | ETH_DMASR_TPS | ETH_DMASR_RPS));
+
+        /* Disable all interrupts */
+        __HAL_ETH_DMA_DISABLE_IT(heth, ETH_DMAIER_NISE | ETH_DMAIER_AISE);
+
+        /* Set HAL state to ERROR */
+        heth->gState = HAL_ETH_STATE_ERROR;
+      }
+      else
+      {
+        /* Get DMA error status  */
+        heth->DMAErrorCode = READ_BIT(heth->Instance->DMASR, (ETH_DMASR_ETS | ETH_DMASR_RWTS |
+                                                              ETH_DMASR_RBUS | ETH_DMASR_AIS));
+
+        /* Clear the interrupt summary flag */
+        __HAL_ETH_DMA_CLEAR_IT(heth, (ETH_DMASR_ETS | ETH_DMASR_RWTS |
+                                      ETH_DMASR_RBUS | ETH_DMASR_AIS));
+      }
+#if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
+      /* Call registered Error callback*/
+      heth->ErrorCallback(heth);
+#else
+      /* Ethernet DMA Error callback */
+      HAL_ETH_ErrorCallback(heth);
+#endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */
+
+    }
+  }
+
+
+  /* ETH PMT IT */
+  if (__HAL_ETH_MAC_GET_IT(heth, ETH_MAC_PMT_IT))
+  {
+    /* Get MAC Wake-up source and clear the status register pending bit */
+    heth->MACWakeUpEvent = READ_BIT(heth->Instance->MACPMTCSR, (ETH_MACPMTCSR_WFR | ETH_MACPMTCSR_MPR));
+
+#if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
+    /* Call registered PMT callback*/
+    heth->PMTCallback(heth);
+#else
+    /* Ethernet PMT callback */
+    HAL_ETH_PMTCallback(heth);
+#endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */
+
+    heth->MACWakeUpEvent = (uint32_t)(0x0U);
+  }
+
+
+  /* check ETH WAKEUP exti flag */
+  if (__HAL_ETH_WAKEUP_EXTI_GET_FLAG(ETH_WAKEUP_EXTI_LINE) != (uint32_t)RESET)
+  {
+    /* Clear ETH WAKEUP Exti pending bit */
+    __HAL_ETH_WAKEUP_EXTI_CLEAR_FLAG(ETH_WAKEUP_EXTI_LINE);
+#if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
+    /* Call registered WakeUp callback*/
+    heth->WakeUpCallback(heth);
+#else
+    /* ETH WAKEUP callback */
+    HAL_ETH_WakeUpCallback(heth);
+#endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
   }
 }
 
 /**
   * @brief  Tx Transfer completed callbacks.
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
   *         the configuration information for ETHERNET module
   * @retval None
   */
@@ -1243,15 +1930,14 @@ __weak void HAL_ETH_TxCpltCallback(ETH_HandleTypeDef *heth)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(heth);
- 
   /* NOTE : This function Should not be modified, when the callback is needed,
   the HAL_ETH_TxCpltCallback could be implemented in the user file
-  */ 
+  */
 }
 
 /**
   * @brief  Rx Transfer completed callbacks.
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
   *         the configuration information for ETHERNET module
   * @retval None
   */
@@ -1259,15 +1945,14 @@ __weak void HAL_ETH_RxCpltCallback(ETH_HandleTypeDef *heth)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(heth);
- 
   /* NOTE : This function Should not be modified, when the callback is needed,
   the HAL_ETH_RxCpltCallback could be implemented in the user file
-  */ 
+  */
 }
 
 /**
   * @brief  Ethernet transfer error callbacks
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
   *         the configuration information for ETHERNET module
   * @retval None
   */
@@ -1275,155 +1960,143 @@ __weak void HAL_ETH_ErrorCallback(ETH_HandleTypeDef *heth)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(heth);
- 
   /* NOTE : This function Should not be modified, when the callback is needed,
   the HAL_ETH_ErrorCallback could be implemented in the user file
-  */ 
+  */
 }
 
 /**
-  * @brief  Reads a PHY register
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module                  
-  * @param PHYReg PHY register address, is the index of one of the 32 PHY register. 
-  *                This parameter can be one of the following values: 
-  *                   PHY_BCR: Transceiver Basic Control Register, 
-  *                   PHY_BSR: Transceiver Basic Status Register.   
-  *                   More PHY register could be read depending on the used PHY
-  * @param RegValue PHY register value                  
+  * @brief  Ethernet Power Management module IT callback
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval None
+  */
+__weak void HAL_ETH_PMTCallback(ETH_HandleTypeDef *heth)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(heth);
+  /* NOTE : This function Should not be modified, when the callback is needed,
+  the HAL_ETH_PMTCallback could be implemented in the user file
+  */
+}
+
+
+/**
+  * @brief  ETH WAKEUP interrupt callback
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval None
+  */
+__weak void HAL_ETH_WakeUpCallback(ETH_HandleTypeDef *heth)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(heth);
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_ETH_WakeUpCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Read a PHY register
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  PHYAddr: PHY port address, must be a value from 0 to 31
+  * @param  PHYReg: PHY register address, must be a value from 0 to 31
+  * @param pRegValue: parameter to hold read value
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ETH_ReadPHYRegister(ETH_HandleTypeDef *heth, uint16_t PHYReg, uint32_t *RegValue)
+HAL_StatusTypeDef HAL_ETH_ReadPHYRegister(ETH_HandleTypeDef *heth, uint32_t PHYAddr, uint32_t PHYReg,
+                                          uint32_t *pRegValue)
 {
-  uint32_t tmpreg = 0;     
-  uint32_t tickstart = 0;
-  
-  /* Check parameters */
-  assert_param(IS_ETH_PHY_ADDRESS(heth->Init.PhyAddress));
-  
-  /* Check the ETH peripheral state */
-  if(heth->State == HAL_ETH_STATE_BUSY_RD)
-  {
-    return HAL_BUSY;
-  }
-  /* Set ETH HAL State to BUSY_RD */
-  heth->State = HAL_ETH_STATE_BUSY_RD;
-  
+  uint32_t tmpreg1;
+  uint32_t tickstart;
+
   /* Get the ETHERNET MACMIIAR value */
-  tmpreg = heth->Instance->MACMIIAR;
-  
+  tmpreg1 = heth->Instance->MACMIIAR;
+
   /* Keep only the CSR Clock Range CR[2:0] bits value */
-  tmpreg &= ~ETH_MACMIIAR_CR_MASK;
-  
+  tmpreg1 &= ~ETH_MACMIIAR_CR_MASK;
+
   /* Prepare the MII address register value */
-  tmpreg |=(((uint32_t)heth->Init.PhyAddress << 11) & ETH_MACMIIAR_PA); /* Set the PHY device address   */
-  tmpreg |=(((uint32_t)PHYReg<<6) & ETH_MACMIIAR_MR);                   /* Set the PHY register address */
-  tmpreg &= ~ETH_MACMIIAR_MW;                                           /* Set the read mode            */
-  tmpreg |= ETH_MACMIIAR_MB;                                            /* Set the MII Busy bit         */
-  
+  tmpreg1 |= ((PHYAddr << 11U) & ETH_MACMIIAR_PA);                        /* Set the PHY device address   */
+  tmpreg1 |= (((uint32_t)PHYReg << 6U) & ETH_MACMIIAR_MR);                /* Set the PHY register address */
+  tmpreg1 &= ~ETH_MACMIIAR_MW;                                            /* Set the read mode            */
+  tmpreg1 |= ETH_MACMIIAR_MB;                                             /* Set the MII Busy bit         */
+
   /* Write the result value into the MII Address register */
-  heth->Instance->MACMIIAR = tmpreg;
-  
-  /* Get tick */
+  heth->Instance->MACMIIAR = tmpreg1;
+
+
   tickstart = HAL_GetTick();
-  
+
   /* Check for the Busy flag */
-  while((tmpreg & ETH_MACMIIAR_MB) == ETH_MACMIIAR_MB)
+  while ((tmpreg1 & ETH_MACMIIAR_MB) == ETH_MACMIIAR_MB)
   {
     /* Check for the Timeout */
-    if((HAL_GetTick() - tickstart ) > PHY_READ_TO)
+    if ((HAL_GetTick() - tickstart) > PHY_READ_TO)
     {
-      heth->State= HAL_ETH_STATE_READY;
-  
-      /* Process Unlocked */
-      __HAL_UNLOCK(heth);
-    
-      return HAL_TIMEOUT;
+      return HAL_ERROR;
     }
-    
-    tmpreg = heth->Instance->MACMIIAR;
+
+    tmpreg1 = heth->Instance->MACMIIAR;
   }
-  
+
   /* Get MACMIIDR value */
-  *RegValue = (uint16_t)(heth->Instance->MACMIIDR);
-  
-  /* Set ETH HAL State to READY */
-  heth->State = HAL_ETH_STATE_READY;
-  
-  /* Return function status */
+  *pRegValue = (uint16_t)(heth->Instance->MACMIIDR);
+
   return HAL_OK;
 }
 
+
 /**
   * @brief  Writes to a PHY register.
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module  
-  * @param  PHYReg PHY register address, is the index of one of the 32 PHY register. 
-  *          This parameter can be one of the following values: 
-  *             PHY_BCR: Transceiver Control Register.  
-  *             More PHY register could be written depending on the used PHY
-  * @param  RegValue the value to write
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  PHYAddr: PHY port address, must be a value from 0 to 31
+  * @param  PHYReg: PHY register address, must be a value from 0 to 31
+  * @param  RegValue: the value to write
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ETH_WritePHYRegister(ETH_HandleTypeDef *heth, uint16_t PHYReg, uint32_t RegValue)
+HAL_StatusTypeDef HAL_ETH_WritePHYRegister(ETH_HandleTypeDef *heth, uint32_t PHYAddr, uint32_t PHYReg,
+                                           uint32_t RegValue)
 {
-  uint32_t tmpreg = 0;
-  uint32_t tickstart = 0;
-  
-  /* Check parameters */
-  assert_param(IS_ETH_PHY_ADDRESS(heth->Init.PhyAddress));
-  
-  /* Check the ETH peripheral state */
-  if(heth->State == HAL_ETH_STATE_BUSY_WR)
-  {
-    return HAL_BUSY;
-  }
-  /* Set ETH HAL State to BUSY_WR */
-  heth->State = HAL_ETH_STATE_BUSY_WR;
-  
+  uint32_t tmpreg1;
+  uint32_t tickstart;
+
   /* Get the ETHERNET MACMIIAR value */
-  tmpreg = heth->Instance->MACMIIAR;
-  
+  tmpreg1 = heth->Instance->MACMIIAR;
+
   /* Keep only the CSR Clock Range CR[2:0] bits value */
-  tmpreg &= ~ETH_MACMIIAR_CR_MASK;
-  
+  tmpreg1 &= ~ETH_MACMIIAR_CR_MASK;
+
   /* Prepare the MII register address value */
-  tmpreg |=(((uint32_t)heth->Init.PhyAddress<<11) & ETH_MACMIIAR_PA); /* Set the PHY device address */
-  tmpreg |=(((uint32_t)PHYReg<<6) & ETH_MACMIIAR_MR);                 /* Set the PHY register address */
-  tmpreg |= ETH_MACMIIAR_MW;                                          /* Set the write mode */
-  tmpreg |= ETH_MACMIIAR_MB;                                          /* Set the MII Busy bit */
-  
+  tmpreg1 |= ((PHYAddr << 11U) & ETH_MACMIIAR_PA);                      /* Set the PHY device address */
+  tmpreg1 |= (((uint32_t)PHYReg << 6U) & ETH_MACMIIAR_MR);              /* Set the PHY register address */
+  tmpreg1 |= ETH_MACMIIAR_MW;                                           /* Set the write mode */
+  tmpreg1 |= ETH_MACMIIAR_MB;                                           /* Set the MII Busy bit */
+
   /* Give the value to the MII data register */
   heth->Instance->MACMIIDR = (uint16_t)RegValue;
-  
+
   /* Write the result value into the MII Address register */
-  heth->Instance->MACMIIAR = tmpreg;
-  
+  heth->Instance->MACMIIAR = tmpreg1;
+
   /* Get tick */
   tickstart = HAL_GetTick();
-  
+
   /* Check for the Busy flag */
-  while((tmpreg & ETH_MACMIIAR_MB) == ETH_MACMIIAR_MB)
+  while ((tmpreg1 & ETH_MACMIIAR_MB) == ETH_MACMIIAR_MB)
   {
     /* Check for the Timeout */
-    if((HAL_GetTick() - tickstart ) > PHY_WRITE_TO)
+    if ((HAL_GetTick() - tickstart) > PHY_WRITE_TO)
     {
-      heth->State= HAL_ETH_STATE_READY;
-  
-      /* Process Unlocked */
-      __HAL_UNLOCK(heth);
-    
-      return HAL_TIMEOUT;
+      return HAL_ERROR;
     }
-    
-    tmpreg = heth->Instance->MACMIIAR;
+
+    tmpreg1 = heth->Instance->MACMIIAR;
   }
-  
-  /* Set ETH HAL State to READY */
-  heth->State = HAL_ETH_STATE_READY;
-  
-  /* Return function status */
-  return HAL_OK; 
+
+  return HAL_OK;
 }
 
 /**
@@ -1431,818 +2104,510 @@ HAL_StatusTypeDef HAL_ETH_WritePHYRegister(ETH_HandleTypeDef *heth, uint16_t PHY
   */
 
 /** @defgroup ETH_Exported_Functions_Group3 Peripheral Control functions
- *  @brief    Peripheral Control functions 
- *
-@verbatim   
- ===============================================================================
-                  ##### Peripheral Control functions #####
- ===============================================================================  
-    [..]  This section provides functions allowing to:
-      (+) Enable MAC and DMA transmission and reception.
-          HAL_ETH_Start();
-      (+) Disable MAC and DMA transmission and reception. 
-          HAL_ETH_Stop();
-      (+) Set the MAC configuration in runtime mode
-          HAL_ETH_ConfigMAC();
-      (+) Set the DMA configuration in runtime mode
-          HAL_ETH_ConfigDMA();
+  *  @brief   ETH control functions
+  *
+@verbatim
+  ==============================================================================
+                      ##### Peripheral Control functions #####
+  ==============================================================================
+  [..]
+    This subsection provides a set of functions allowing to control the ETH
+    peripheral.
 
 @endverbatim
   * @{
-  */ 
-
- /**
-  * @brief  Enables Ethernet MAC and DMA reception/transmission 
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ETH_Start(ETH_HandleTypeDef *heth)
-{  
-  /* Process Locked */
-  __HAL_LOCK(heth);
-  
-  /* Set the ETH peripheral state to BUSY */
-  heth->State = HAL_ETH_STATE_BUSY;
-  
-  /* Enable transmit state machine of the MAC for transmission on the MII */
-  ETH_MACTransmissionEnable(heth);
-  
-  /* Enable receive state machine of the MAC for reception from the MII */
-  ETH_MACReceptionEnable(heth);
-  
-  /* Flush Transmit FIFO */
-  ETH_FlushTransmitFIFO(heth);
-  
-  /* Start DMA transmission */
-  ETH_DMATransmissionEnable(heth);
-  
-  /* Start DMA reception */
-  ETH_DMAReceptionEnable(heth);
-  
-  /* Set the ETH state to READY*/
-  heth->State= HAL_ETH_STATE_READY;
-  
-  /* Process Unlocked */
-  __HAL_UNLOCK(heth);
-  
-  /* Return function status */
+/**
+  * @brief  Get the configuration of the MAC and MTL subsystems.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  macconf: pointer to a ETH_MACConfigTypeDef structure that will hold
+  *         the configuration of the MAC.
+  * @retval HAL Status
+  */
+HAL_StatusTypeDef HAL_ETH_GetMACConfig(ETH_HandleTypeDef *heth, ETH_MACConfigTypeDef *macconf)
+{
+  if (macconf == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Get MAC parameters */
+  macconf->DeferralCheck = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_DC) >> 4) > 0U) ? ENABLE : DISABLE;
+  macconf->BackOffLimit = READ_BIT(heth->Instance->MACCR, ETH_MACCR_BL);
+  macconf->RetryTransmission = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_RD) >> 9) == 0U) ? ENABLE : DISABLE;
+  macconf->CarrierSenseDuringTransmit = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_CSD) >> 16) > 0U)
+                                        ? ENABLE : DISABLE;
+  macconf->ReceiveOwn = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_ROD) >> 13) == 0U) ? ENABLE : DISABLE;
+  macconf->LoopbackMode = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_LM) >> 12) > 0U) ? ENABLE : DISABLE;
+  macconf->DuplexMode = READ_BIT(heth->Instance->MACCR, ETH_MACCR_DM);
+  macconf->Speed = READ_BIT(heth->Instance->MACCR, ETH_MACCR_FES);
+  macconf->Jabber = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_JD) >> 22) == 0U) ? ENABLE : DISABLE;
+  macconf->Watchdog = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_WD) >> 23) == 0U) ? ENABLE : DISABLE;
+  macconf->AutomaticPadCRCStrip = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_APCS) >> 7) > 0U) ? ENABLE : DISABLE;
+  macconf->InterPacketGapVal = READ_BIT(heth->Instance->MACCR, ETH_MACCR_IFG);
+  macconf->ChecksumOffload = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_IPCO) >> 27) > 0U) ? ENABLE : DISABLE;
+
+
+  macconf->TransmitFlowControl = ((READ_BIT(heth->Instance->MACFCR, ETH_MACFCR_TFCE) >> 1) > 0U) ? ENABLE : DISABLE;
+  macconf->ZeroQuantaPause = ((READ_BIT(heth->Instance->MACFCR, ETH_MACFCR_ZQPD) >> 7) == 0U) ? ENABLE : DISABLE;
+  macconf->PauseLowThreshold = READ_BIT(heth->Instance->MACFCR, ETH_MACFCR_PLT);
+  macconf->PauseTime = (READ_BIT(heth->Instance->MACFCR, ETH_MACFCR_PT) >> 16);
+  macconf->ReceiveFlowControl = (READ_BIT(heth->Instance->MACFCR, ETH_MACFCR_RFCE) > 0U) ? ENABLE : DISABLE;
+  macconf->UnicastPausePacketDetect = ((READ_BIT(heth->Instance->MACFCR, ETH_MACFCR_UPFD) >> 1) > 0U)
+                                      ? ENABLE : DISABLE;
+
   return HAL_OK;
 }
 
 /**
-  * @brief  Stop Ethernet MAC and DMA reception/transmission 
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
+  * @brief  Get the configuration of the DMA.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
   *         the configuration information for ETHERNET module
-  * @retval HAL status
+  * @param  dmaconf: pointer to a ETH_DMAConfigTypeDef structure that will hold
+  *         the configuration of the ETH DMA.
+  * @retval HAL Status
   */
-HAL_StatusTypeDef HAL_ETH_Stop(ETH_HandleTypeDef *heth)
-{  
-  /* Process Locked */
-  __HAL_LOCK(heth);
-  
-  /* Set the ETH peripheral state to BUSY */
-  heth->State = HAL_ETH_STATE_BUSY;
-  
-  /* Stop DMA transmission */
-  ETH_DMATransmissionDisable(heth);
-  
-  /* Stop DMA reception */
-  ETH_DMAReceptionDisable(heth);
-  
-  /* Disable receive state machine of the MAC for reception from the MII */
-  ETH_MACReceptionDisable(heth);
-  
-  /* Flush Transmit FIFO */
-  ETH_FlushTransmitFIFO(heth);
-  
-  /* Disable transmit state machine of the MAC for transmission on the MII */
-  ETH_MACTransmissionDisable(heth);
-  
-  /* Set the ETH state*/
-  heth->State = HAL_ETH_STATE_READY;
-  
-  /* Process Unlocked */
-  __HAL_UNLOCK(heth);
-  
-  /* Return function status */
+HAL_StatusTypeDef HAL_ETH_GetDMAConfig(ETH_HandleTypeDef *heth, ETH_DMAConfigTypeDef *dmaconf)
+{
+  if (dmaconf == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  dmaconf->DMAArbitration = READ_BIT(heth->Instance->DMABMR, ETH_DMABMR_DSL) >> 2;
+  dmaconf->AddressAlignedBeats = ((READ_BIT(heth->Instance->DMABMR, ETH_DMABMR_AAB) >> 12) > 0U) ? ENABLE : DISABLE;
+  dmaconf->BurstMode = READ_BIT(heth->Instance->DMABMR, ETH_DMABMR_FB | ETH_DMABMR_MB);
+  dmaconf->RxDMABurstLength = READ_BIT(heth->Instance->DMABMR, ETH_DMABMR_RDP);
+  dmaconf->TxDMABurstLength = READ_BIT(heth->Instance->DMABMR, ETH_DMABMR_PBL);
+  dmaconf->EnhancedDescriptorFormat = ((READ_BIT(heth->Instance->DMABMR, ETH_DMABMR_EDE) >> 7) > 0U) ? ENABLE : DISABLE;
+  dmaconf->DescriptorSkipLength = READ_BIT(heth->Instance->DMABMR, ETH_DMABMR_DSL) >> 2;
+
+  dmaconf->DropTCPIPChecksumErrorFrame = ((READ_BIT(heth->Instance->DMAOMR,
+                                                    ETH_DMAOMR_DTCEFD) >> 26) > 0U) ? DISABLE : ENABLE;
+  dmaconf->ReceiveStoreForward = ((READ_BIT(heth->Instance->DMAOMR, ETH_DMAOMR_RSF) >> 25) > 0U) ? ENABLE : DISABLE;
+  dmaconf->FlushRxPacket = ((READ_BIT(heth->Instance->DMAOMR, ETH_DMAOMR_FTF) >> 20) > 0U) ? DISABLE : ENABLE;
+  dmaconf->TransmitStoreForward = ((READ_BIT(heth->Instance->DMAOMR, ETH_DMAOMR_TSF) >> 21) > 0U) ? ENABLE : DISABLE;
+  dmaconf->TransmitThresholdControl = READ_BIT(heth->Instance->DMAOMR, ETH_DMAOMR_TTC);
+  dmaconf->ForwardErrorFrames = ((READ_BIT(heth->Instance->DMAOMR, ETH_DMAOMR_FEF) >> 7) > 0U) ? ENABLE : DISABLE;
+  dmaconf->ForwardUndersizedGoodFrames = ((READ_BIT(heth->Instance->DMAOMR,
+                                                    ETH_DMAOMR_FUGF) >> 6) > 0U) ? ENABLE : DISABLE;
+  dmaconf->ReceiveThresholdControl = READ_BIT(heth->Instance->DMAOMR, ETH_DMAOMR_RTC);
+  dmaconf->SecondFrameOperate = ((READ_BIT(heth->Instance->DMAOMR, ETH_DMAOMR_OSF) >> 2) > 0U) ? ENABLE : DISABLE;
   return HAL_OK;
 }
 
 /**
-  * @brief  Set ETH MAC Configuration.
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
+  * @brief  Set the MAC configuration.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
   *         the configuration information for ETHERNET module
-  * @param  macconf MAC Configuration structure  
+  * @param  macconf: pointer to a ETH_MACConfigTypeDef structure that contains
+  *         the configuration of the MAC.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ETH_ConfigMAC(ETH_HandleTypeDef *heth, ETH_MACInitTypeDef *macconf)
+HAL_StatusTypeDef HAL_ETH_SetMACConfig(ETH_HandleTypeDef *heth,  ETH_MACConfigTypeDef *macconf)
 {
-  uint32_t tmpreg = 0;
-  
-  /* Process Locked */
-  __HAL_LOCK(heth);
-  
-  /* Set the ETH peripheral state to BUSY */
-  heth->State= HAL_ETH_STATE_BUSY;
-  
-  assert_param(IS_ETH_SPEED(heth->Init.Speed));
-  assert_param(IS_ETH_DUPLEX_MODE(heth->Init.DuplexMode)); 
-  
-  if (macconf != NULL)
+  if (macconf == NULL)
   {
-    /* Check the parameters */
-    assert_param(IS_ETH_WATCHDOG(macconf->Watchdog));
-    assert_param(IS_ETH_JABBER(macconf->Jabber));
-    assert_param(IS_ETH_INTER_FRAME_GAP(macconf->InterFrameGap));
-    assert_param(IS_ETH_CARRIER_SENSE(macconf->CarrierSense));
-    assert_param(IS_ETH_RECEIVE_OWN(macconf->ReceiveOwn));
-    assert_param(IS_ETH_LOOPBACK_MODE(macconf->LoopbackMode));
-    assert_param(IS_ETH_CHECKSUM_OFFLOAD(macconf->ChecksumOffload));
-    assert_param(IS_ETH_RETRY_TRANSMISSION(macconf->RetryTransmission));
-    assert_param(IS_ETH_AUTOMATIC_PADCRC_STRIP(macconf->AutomaticPadCRCStrip));
-    assert_param(IS_ETH_BACKOFF_LIMIT(macconf->BackOffLimit));
-    assert_param(IS_ETH_DEFERRAL_CHECK(macconf->DeferralCheck));
-    assert_param(IS_ETH_RECEIVE_ALL(macconf->ReceiveAll));
-    assert_param(IS_ETH_SOURCE_ADDR_FILTER(macconf->SourceAddrFilter));
-    assert_param(IS_ETH_CONTROL_FRAMES(macconf->PassControlFrames));
-    assert_param(IS_ETH_BROADCAST_FRAMES_RECEPTION(macconf->BroadcastFramesReception));
-    assert_param(IS_ETH_DESTINATION_ADDR_FILTER(macconf->DestinationAddrFilter));
-    assert_param(IS_ETH_PROMISCUOUS_MODE(macconf->PromiscuousMode));
-    assert_param(IS_ETH_MULTICAST_FRAMES_FILTER(macconf->MulticastFramesFilter));
-    assert_param(IS_ETH_UNICAST_FRAMES_FILTER(macconf->UnicastFramesFilter));
-    assert_param(IS_ETH_PAUSE_TIME(macconf->PauseTime));
-    assert_param(IS_ETH_ZEROQUANTA_PAUSE(macconf->ZeroQuantaPause));
-    assert_param(IS_ETH_PAUSE_LOW_THRESHOLD(macconf->PauseLowThreshold));
-    assert_param(IS_ETH_UNICAST_PAUSE_FRAME_DETECT(macconf->UnicastPauseFrameDetect));
-    assert_param(IS_ETH_RECEIVE_FLOWCONTROL(macconf->ReceiveFlowControl));
-    assert_param(IS_ETH_TRANSMIT_FLOWCONTROL(macconf->TransmitFlowControl));
-    assert_param(IS_ETH_VLAN_TAG_COMPARISON(macconf->VLANTagComparison));
-    assert_param(IS_ETH_VLAN_TAG_IDENTIFIER(macconf->VLANTagIdentifier));
-    
-    /*------------------------ ETHERNET MACCR Configuration --------------------*/
-    /* Get the ETHERNET MACCR value */
-    tmpreg = (heth->Instance)->MACCR;
-    /* Clear WD, PCE, PS, TE and RE bits */
-    tmpreg &= ETH_MACCR_CLEAR_MASK;
-    
-    tmpreg |= (uint32_t)(macconf->Watchdog | 
-                         macconf->Jabber | 
-                         macconf->InterFrameGap |
-                         macconf->CarrierSense |
-                         (heth->Init).Speed | 
-                         macconf->ReceiveOwn |
-                         macconf->LoopbackMode |
-                         (heth->Init).DuplexMode | 
-                         macconf->ChecksumOffload |    
-                         macconf->RetryTransmission | 
-                         macconf->AutomaticPadCRCStrip | 
-                         macconf->BackOffLimit | 
-                         macconf->DeferralCheck);
-    
-    /* Write to ETHERNET MACCR */
-    (heth->Instance)->MACCR = (uint32_t)tmpreg;
-    
-    /* Wait until the write operation will be taken into account :
-    at least four TX_CLK/RX_CLK clock cycles */
-    tmpreg = (heth->Instance)->MACCR;
-    HAL_Delay(ETH_REG_WRITE_DELAY);
-    (heth->Instance)->MACCR = tmpreg; 
-    
-    /*----------------------- ETHERNET MACFFR Configuration --------------------*/ 
-    /* Write to ETHERNET MACFFR */  
-    (heth->Instance)->MACFFR = (uint32_t)(macconf->ReceiveAll | 
-                                          macconf->SourceAddrFilter |
-                                          macconf->PassControlFrames |
-                                          macconf->BroadcastFramesReception | 
-                                          macconf->DestinationAddrFilter |
-                                          macconf->PromiscuousMode |
-                                          macconf->MulticastFramesFilter |
-                                          macconf->UnicastFramesFilter);
-     
-     /* Wait until the write operation will be taken into account :
-     at least four TX_CLK/RX_CLK clock cycles */
-     tmpreg = (heth->Instance)->MACFFR;
-     HAL_Delay(ETH_REG_WRITE_DELAY);
-     (heth->Instance)->MACFFR = tmpreg;
-     
-     /*--------------- ETHERNET MACHTHR and MACHTLR Configuration ---------------*/
-     /* Write to ETHERNET MACHTHR */
-     (heth->Instance)->MACHTHR = (uint32_t)macconf->HashTableHigh;
-     
-     /* Write to ETHERNET MACHTLR */
-     (heth->Instance)->MACHTLR = (uint32_t)macconf->HashTableLow;
-     /*----------------------- ETHERNET MACFCR Configuration --------------------*/
-     
-     /* Get the ETHERNET MACFCR value */  
-     tmpreg = (heth->Instance)->MACFCR;
-     /* Clear xx bits */
-     tmpreg &= ETH_MACFCR_CLEAR_MASK;
-     
-     tmpreg |= (uint32_t)((macconf->PauseTime << 16) | 
-                          macconf->ZeroQuantaPause |
-                          macconf->PauseLowThreshold |
-                          macconf->UnicastPauseFrameDetect | 
-                          macconf->ReceiveFlowControl |
-                          macconf->TransmitFlowControl); 
-     
-     /* Write to ETHERNET MACFCR */
-     (heth->Instance)->MACFCR = (uint32_t)tmpreg;
-     
-     /* Wait until the write operation will be taken into account :
-     at least four TX_CLK/RX_CLK clock cycles */
-     tmpreg = (heth->Instance)->MACFCR;
-     HAL_Delay(ETH_REG_WRITE_DELAY);
-     (heth->Instance)->MACFCR = tmpreg;
-     
-     /*----------------------- ETHERNET MACVLANTR Configuration -----------------*/
-     (heth->Instance)->MACVLANTR = (uint32_t)(macconf->VLANTagComparison | 
-                                              macconf->VLANTagIdentifier);
-      
-      /* Wait until the write operation will be taken into account :
-      at least four TX_CLK/RX_CLK clock cycles */
-      tmpreg = (heth->Instance)->MACVLANTR;
-      HAL_Delay(ETH_REG_WRITE_DELAY);
-      (heth->Instance)->MACVLANTR = tmpreg;
+    return HAL_ERROR;
   }
-  else /* macconf == NULL : here we just configure Speed and Duplex mode */
+
+  if (heth->gState == HAL_ETH_STATE_READY)
   {
-    /*------------------------ ETHERNET MACCR Configuration --------------------*/
-    /* Get the ETHERNET MACCR value */
-    tmpreg = (heth->Instance)->MACCR;
-    
-    /* Clear FES and DM bits */
-    tmpreg &= ~((uint32_t)0x00004800);
-    
-    tmpreg |= (uint32_t)(heth->Init.Speed | heth->Init.DuplexMode);
-    
-    /* Write to ETHERNET MACCR */
-    (heth->Instance)->MACCR = (uint32_t)tmpreg;
-    
-    /* Wait until the write operation will be taken into account:
-    at least four TX_CLK/RX_CLK clock cycles */
-    tmpreg = (heth->Instance)->MACCR;
-    HAL_Delay(ETH_REG_WRITE_DELAY);
-    (heth->Instance)->MACCR = tmpreg;
+    ETH_SetMACConfig(heth, macconf);
+
+    return HAL_OK;
   }
-  
-  /* Set the ETH state to Ready */
-  heth->State= HAL_ETH_STATE_READY;
-  
-  /* Process Unlocked */
-  __HAL_UNLOCK(heth);
-  
-  /* Return function status */
-  return HAL_OK;  
+  else
+  {
+    return HAL_ERROR;
+  }
 }
 
 /**
-  * @brief  Sets ETH DMA Configuration.
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
+  * @brief  Set the ETH DMA configuration.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
   *         the configuration information for ETHERNET module
-  * @param  dmaconf DMA Configuration structure  
+  * @param  dmaconf: pointer to a ETH_DMAConfigTypeDef structure that will hold
+  *         the configuration of the ETH DMA.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ETH_ConfigDMA(ETH_HandleTypeDef *heth, ETH_DMAInitTypeDef *dmaconf)
+HAL_StatusTypeDef HAL_ETH_SetDMAConfig(ETH_HandleTypeDef *heth,  ETH_DMAConfigTypeDef *dmaconf)
 {
-  uint32_t tmpreg = 0;
+  if (dmaconf == NULL)
+  {
+    return HAL_ERROR;
+  }
 
-  /* Process Locked */
-  __HAL_LOCK(heth);
-  
-  /* Set the ETH peripheral state to BUSY */
-  heth->State= HAL_ETH_STATE_BUSY;
+  if (heth->gState == HAL_ETH_STATE_READY)
+  {
+    ETH_SetDMAConfig(heth, dmaconf);
 
-  /* Check parameters */
-  assert_param(IS_ETH_DROP_TCPIP_CHECKSUM_FRAME(dmaconf->DropTCPIPChecksumErrorFrame));
-  assert_param(IS_ETH_RECEIVE_STORE_FORWARD(dmaconf->ReceiveStoreForward));
-  assert_param(IS_ETH_FLUSH_RECEIVE_FRAME(dmaconf->FlushReceivedFrame));
-  assert_param(IS_ETH_TRANSMIT_STORE_FORWARD(dmaconf->TransmitStoreForward));
-  assert_param(IS_ETH_TRANSMIT_THRESHOLD_CONTROL(dmaconf->TransmitThresholdControl));
-  assert_param(IS_ETH_FORWARD_ERROR_FRAMES(dmaconf->ForwardErrorFrames));
-  assert_param(IS_ETH_FORWARD_UNDERSIZED_GOOD_FRAMES(dmaconf->ForwardUndersizedGoodFrames));
-  assert_param(IS_ETH_RECEIVE_THRESHOLD_CONTROL(dmaconf->ReceiveThresholdControl));
-  assert_param(IS_ETH_SECOND_FRAME_OPERATE(dmaconf->SecondFrameOperate));
-  assert_param(IS_ETH_ADDRESS_ALIGNED_BEATS(dmaconf->AddressAlignedBeats));
-  assert_param(IS_ETH_FIXED_BURST(dmaconf->FixedBurst));
-  assert_param(IS_ETH_RXDMA_BURST_LENGTH(dmaconf->RxDMABurstLength));
-  assert_param(IS_ETH_TXDMA_BURST_LENGTH(dmaconf->TxDMABurstLength));
-  assert_param(IS_ETH_ENHANCED_DESCRIPTOR_FORMAT(dmaconf->EnhancedDescriptorFormat));
-  assert_param(IS_ETH_DMA_DESC_SKIP_LENGTH(dmaconf->DescriptorSkipLength));
-  assert_param(IS_ETH_DMA_ARBITRATION_ROUNDROBIN_RXTX(dmaconf->DMAArbitration));
-  
-  /*----------------------- ETHERNET DMAOMR Configuration --------------------*/
-  /* Get the ETHERNET DMAOMR value */
-  tmpreg = (heth->Instance)->DMAOMR;
-  /* Clear xx bits */
-  tmpreg &= ETH_DMAOMR_CLEAR_MASK;
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+}
 
-  tmpreg |= (uint32_t)(dmaconf->DropTCPIPChecksumErrorFrame | 
-                       dmaconf->ReceiveStoreForward |
-                       dmaconf->FlushReceivedFrame |
-                       dmaconf->TransmitStoreForward | 
-                       dmaconf->TransmitThresholdControl |
-                       dmaconf->ForwardErrorFrames |
-                       dmaconf->ForwardUndersizedGoodFrames |
-                       dmaconf->ReceiveThresholdControl |
-                       dmaconf->SecondFrameOperate);
+/**
+  * @brief  Configures the Clock range of ETH MDIO interface.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval None
+  */
+void HAL_ETH_SetMDIOClockRange(ETH_HandleTypeDef *heth)
+{
+  uint32_t hclk;
+  uint32_t tmpreg;
 
-  /* Write to ETHERNET DMAOMR */
-  (heth->Instance)->DMAOMR = (uint32_t)tmpreg;
+  /* Get the ETHERNET MACMIIAR value */
+  tmpreg = (heth->Instance)->MACMIIAR;
+  /* Clear CSR Clock Range CR[2:0] bits */
+  tmpreg &= ETH_MACMIIAR_CR_MASK;
 
-  /* Wait until the write operation will be taken into account:
-  at least four TX_CLK/RX_CLK clock cycles */
-  tmpreg = (heth->Instance)->DMAOMR;
-  HAL_Delay(ETH_REG_WRITE_DELAY);
-  (heth->Instance)->DMAOMR = tmpreg;
+  /* Get hclk frequency value */
+  hclk = HAL_RCC_GetHCLKFreq();
 
-  /*----------------------- ETHERNET DMABMR Configuration --------------------*/
-  (heth->Instance)->DMABMR = (uint32_t)(dmaconf->AddressAlignedBeats | 
-                                         dmaconf->FixedBurst |
-                                         dmaconf->RxDMABurstLength | /* !! if 4xPBL is selected for Tx or Rx it is applied for the other */
-                                         dmaconf->TxDMABurstLength |
-                                         dmaconf->EnhancedDescriptorFormat |
-                                         (dmaconf->DescriptorSkipLength << 2) |
-                                         dmaconf->DMAArbitration | 
-                                         ETH_DMABMR_USP); /* Enable use of separate PBL for Rx and Tx */
+  /* Set CR bits depending on hclk value */
+  if ((hclk >= 20000000U) && (hclk < 35000000U))
+  {
+    /* CSR Clock Range between 20-35 MHz */
+    tmpreg |= (uint32_t)ETH_MACMIIAR_CR_Div16;
+  }
+  else if ((hclk >= 35000000U) && (hclk < 60000000U))
+  {
+    /* CSR Clock Range between 35-60 MHz */
+    tmpreg |= (uint32_t)ETH_MACMIIAR_CR_Div26;
+  }
+  else if ((hclk >= 60000000U) && (hclk < 100000000U))
+  {
+    /* CSR Clock Range between 60-100 MHz */
+    tmpreg |= (uint32_t)ETH_MACMIIAR_CR_Div42;
+  }
+  else if ((hclk >= 100000000U) && (hclk < 150000000U))
+  {
+    /* CSR Clock Range between 100-150 MHz */
+    tmpreg |= (uint32_t)ETH_MACMIIAR_CR_Div62;
+  }
+  else /* ((hclk >= 150000000)&&(hclk <= 183000000))*/
+  {
+    /* CSR Clock Range between 150-183 MHz */
+    tmpreg |= (uint32_t)ETH_MACMIIAR_CR_Div102;
+  }
 
-   /* Wait until the write operation will be taken into account:
-      at least four TX_CLK/RX_CLK clock cycles */
-   tmpreg = (heth->Instance)->DMABMR;
-   HAL_Delay(ETH_REG_WRITE_DELAY);
-   (heth->Instance)->DMABMR = tmpreg;
+  /* Write to ETHERNET MAC MIIAR: Configure the ETHERNET CSR Clock Range */
+  (heth->Instance)->MACMIIAR = (uint32_t)tmpreg;
+}
 
-   /* Set the ETH state to Ready */
-   heth->State= HAL_ETH_STATE_READY;
-   
-   /* Process Unlocked */
-   __HAL_UNLOCK(heth);
-   
-   /* Return function status */
-   return HAL_OK; 
+/**
+  * @brief  Set the ETH MAC (L2) Filters configuration.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  pFilterConfig: pointer to a ETH_MACFilterConfigTypeDef structure that contains
+  *         the configuration of the ETH MAC filters.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_SetMACFilterConfig(ETH_HandleTypeDef *heth, ETH_MACFilterConfigTypeDef *pFilterConfig)
+{
+  uint32_t filterconfig;
+
+  if (pFilterConfig == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  filterconfig = ((uint32_t)pFilterConfig->PromiscuousMode |
+                  ((uint32_t)pFilterConfig->HashUnicast << 1) |
+                  ((uint32_t)pFilterConfig->HashMulticast << 2)  |
+                  ((uint32_t)pFilterConfig->DestAddrInverseFiltering << 3) |
+                  ((uint32_t)pFilterConfig->PassAllMulticast << 4) |
+                  ((uint32_t)((pFilterConfig->BroadcastFilter == DISABLE) ? 1U : 0U) << 5) |
+                  ((uint32_t)pFilterConfig->SrcAddrInverseFiltering << 8) |
+                  ((uint32_t)pFilterConfig->SrcAddrFiltering << 9) |
+                  ((uint32_t)pFilterConfig->HachOrPerfectFilter << 10) |
+                  ((uint32_t)pFilterConfig->ReceiveAllMode << 31) |
+                  pFilterConfig->ControlPacketsFilter);
+
+  MODIFY_REG(heth->Instance->MACFFR, ETH_MACFFR_MASK, filterconfig);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Get the ETH MAC (L2) Filters configuration.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  pFilterConfig: pointer to a ETH_MACFilterConfigTypeDef structure that will hold
+  *         the configuration of the ETH MAC filters.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_GetMACFilterConfig(ETH_HandleTypeDef *heth, ETH_MACFilterConfigTypeDef *pFilterConfig)
+{
+  if (pFilterConfig == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  pFilterConfig->PromiscuousMode = ((READ_BIT(heth->Instance->MACFFR, ETH_MACFFR_PM)) > 0U) ? ENABLE : DISABLE;
+  pFilterConfig->HashUnicast = ((READ_BIT(heth->Instance->MACFFR, ETH_MACFFR_HU) >> 1) > 0U) ? ENABLE : DISABLE;
+  pFilterConfig->HashMulticast = ((READ_BIT(heth->Instance->MACFFR, ETH_MACFFR_HM) >> 2) > 0U) ? ENABLE : DISABLE;
+  pFilterConfig->DestAddrInverseFiltering = ((READ_BIT(heth->Instance->MACFFR,
+                                                       ETH_MACFFR_DAIF) >> 3) > 0U) ? ENABLE : DISABLE;
+  pFilterConfig->PassAllMulticast = ((READ_BIT(heth->Instance->MACFFR, ETH_MACFFR_PAM) >> 4) > 0U) ? ENABLE : DISABLE;
+  pFilterConfig->BroadcastFilter = ((READ_BIT(heth->Instance->MACFFR, ETH_MACFFR_BFD) >> 5) == 0U) ? ENABLE : DISABLE;
+  pFilterConfig->ControlPacketsFilter = READ_BIT(heth->Instance->MACFFR, ETH_MACFFR_PCF);
+  pFilterConfig->SrcAddrInverseFiltering = ((READ_BIT(heth->Instance->MACFFR,
+                                                      ETH_MACFFR_SAIF) >> 8) > 0U) ? ENABLE : DISABLE;
+  pFilterConfig->SrcAddrFiltering = ((READ_BIT(heth->Instance->MACFFR, ETH_MACFFR_SAF) >> 9) > 0U) ? ENABLE : DISABLE;
+  pFilterConfig->HachOrPerfectFilter = ((READ_BIT(heth->Instance->MACFFR, ETH_MACFFR_HPF) >> 10) > 0U)
+                                       ? ENABLE : DISABLE;
+  pFilterConfig->ReceiveAllMode = ((READ_BIT(heth->Instance->MACFFR, ETH_MACFFR_RA) >> 31) > 0U) ? ENABLE : DISABLE;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set the source MAC Address to be matched.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  AddrNbr: The MAC address to configure
+  *          This parameter must be a value of the following:
+  *            ETH_MAC_ADDRESS1
+  *            ETH_MAC_ADDRESS2
+  *            ETH_MAC_ADDRESS3
+  * @param  pMACAddr: Pointer to MAC address buffer data (6 bytes)
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_SetSourceMACAddrMatch(ETH_HandleTypeDef *heth, uint32_t AddrNbr, uint8_t *pMACAddr)
+{
+  uint32_t macaddrlr;
+  uint32_t macaddrhr;
+
+  if (pMACAddr == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Get mac addr high reg offset */
+  macaddrhr = ((uint32_t) &(heth->Instance->MACA0HR) + AddrNbr);
+  /* Get mac addr low reg offset */
+  macaddrlr = ((uint32_t) &(heth->Instance->MACA0LR) + AddrNbr);
+
+  /* Set MAC addr bits 32 to 47 */
+  (*(__IO uint32_t *)macaddrhr) = (((uint32_t)(pMACAddr[5]) << 8) | (uint32_t)pMACAddr[4]);
+  /* Set MAC addr bits 0 to 31 */
+  (*(__IO uint32_t *)macaddrlr) = (((uint32_t)(pMACAddr[3]) << 24) | ((uint32_t)(pMACAddr[2]) << 16) |
+                                   ((uint32_t)(pMACAddr[1]) << 8) | (uint32_t)pMACAddr[0]);
+
+  /* Enable address and set source address bit */
+  (*(__IO uint32_t *)macaddrhr) |= (ETH_MACA1HR_AE | ETH_MACA1HR_SA);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set the ETH Hash Table Value.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  pHashTable: pointer to a table of two 32 bit values, that contains
+  *         the 64 bits of the hash table.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_SetHashTable(ETH_HandleTypeDef *heth, uint32_t *pHashTable)
+{
+  if (pHashTable == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  heth->Instance->MACHTHR = pHashTable[0];
+  heth->Instance->MACHTLR = pHashTable[1];
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set the VLAN Identifier for Rx packets
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  ComparisonBits: 12 or 16 bit comparison mode
+            must be a value of @ref ETH_VLAN_Tag_Comparison
+  * @param  VLANIdentifier: VLAN Identifier value
+  * @retval None
+  */
+void HAL_ETH_SetRxVLANIdentifier(ETH_HandleTypeDef *heth, uint32_t ComparisonBits, uint32_t VLANIdentifier)
+{
+  MODIFY_REG(heth->Instance->MACVLANTR, ETH_MACVLANTR_VLANTI, VLANIdentifier);
+  if (ComparisonBits == ETH_VLANTAGCOMPARISON_16BIT)
+  {
+    CLEAR_BIT(heth->Instance->MACVLANTR, ETH_MACVLANTR_VLANTC);
+  }
+  else
+  {
+    SET_BIT(heth->Instance->MACVLANTR, ETH_MACVLANTR_VLANTC);
+  }
+}
+
+/**
+  * @brief  Enters the Power down mode.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  pPowerDownConfig: a pointer to ETH_PowerDownConfigTypeDef structure
+  *         that contains the Power Down configuration
+  * @retval None.
+  */
+void HAL_ETH_EnterPowerDownMode(ETH_HandleTypeDef *heth, ETH_PowerDownConfigTypeDef *pPowerDownConfig)
+{
+  uint32_t powerdownconfig;
+
+  powerdownconfig = (((uint32_t)pPowerDownConfig->MagicPacket << ETH_MACPMTCSR_MPE_Pos) |
+                     ((uint32_t)pPowerDownConfig->WakeUpPacket << ETH_MACPMTCSR_WFE_Pos) |
+                     ((uint32_t)pPowerDownConfig->GlobalUnicast << ETH_MACPMTCSR_GU_Pos) |
+                     ETH_MACPMTCSR_PD);
+
+  MODIFY_REG(heth->Instance->MACPMTCSR, ETH_MACPMTCSR_MASK, powerdownconfig);
+}
+
+/**
+  * @brief  Exits from the Power down mode.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval None.
+  */
+void HAL_ETH_ExitPowerDownMode(ETH_HandleTypeDef *heth)
+{
+  /* clear wake up sources */
+  CLEAR_BIT(heth->Instance->MACPMTCSR, ETH_MACPMTCSR_WFE | ETH_MACPMTCSR_MPE | ETH_MACPMTCSR_GU);
+
+  if (READ_BIT(heth->Instance->MACPMTCSR, ETH_MACPMTCSR_PD) != 0U)
+  {
+    /* Exit power down mode */
+    CLEAR_BIT(heth->Instance->MACPMTCSR, ETH_MACPMTCSR_PD);
+  }
+
+  /* Disable PMT interrupt */
+  SET_BIT(heth->Instance->MACIMR, ETH_MACIMR_PMTIM);
+}
+
+/**
+  * @brief  Set the WakeUp filter.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  pFilter: pointer to filter registers values
+  * @param  Count: number of filter registers, must be from 1 to 8.
+  * @retval None.
+  */
+HAL_StatusTypeDef HAL_ETH_SetWakeUpFilter(ETH_HandleTypeDef *heth, uint32_t *pFilter, uint32_t Count)
+{
+  uint32_t regindex;
+
+  if (pFilter == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Reset Filter Pointer */
+  SET_BIT(heth->Instance->MACPMTCSR, ETH_MACPMTCSR_WFFRPR);
+
+  /* Wake up packet filter config */
+  for (regindex = 0; regindex < Count; regindex++)
+  {
+    /* Write filter regs */
+    WRITE_REG(heth->Instance->MACRWUFFR, pFilter[regindex]);
+  }
+
+  return HAL_OK;
 }
 
 /**
   * @}
   */
 
-/** @defgroup ETH_Exported_Functions_Group4 Peripheral State functions 
-  *  @brief   Peripheral State functions 
+/** @defgroup ETH_Exported_Functions_Group4 Peripheral State and Errors functions
+  *  @brief   ETH State and Errors functions
   *
-  @verbatim   
-  ===============================================================================
-                         ##### Peripheral State functions #####
-  ===============================================================================  
-  [..]
-  This subsection permits to get in run-time the status of the peripheral 
-  and the data flow.
-       (+) Get the ETH handle state:
-           HAL_ETH_GetState();
-           
+@verbatim
+  ==============================================================================
+                 ##### Peripheral State and Errors functions #####
+  ==============================================================================
+ [..]
+   This subsection provides a set of functions allowing to return the State of
+   ETH communication process, return Peripheral Errors occurred during communication
+   process
 
-  @endverbatim
+
+@endverbatim
   * @{
   */
 
 /**
-  * @brief  Return the ETH HAL state
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
+  * @brief  Returns the ETH state.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
   *         the configuration information for ETHERNET module
   * @retval HAL state
   */
 HAL_ETH_StateTypeDef HAL_ETH_GetState(ETH_HandleTypeDef *heth)
-{  
-  /* Return ETH state */
-  return heth->State;
+{
+  return heth->gState;
+}
+
+/**
+  * @brief  Returns the ETH error code
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval ETH Error Code
+  */
+uint32_t HAL_ETH_GetError(ETH_HandleTypeDef *heth)
+{
+  return heth->ErrorCode;
+}
+
+/**
+  * @brief  Returns the ETH DMA error code
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval ETH DMA Error Code
+  */
+uint32_t HAL_ETH_GetDMAError(ETH_HandleTypeDef *heth)
+{
+  return heth->DMAErrorCode;
+}
+
+/**
+  * @brief  Returns the ETH MAC error code
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval ETH MAC Error Code
+  */
+uint32_t HAL_ETH_GetMACError(ETH_HandleTypeDef *heth)
+{
+  return heth->MACErrorCode;
+}
+
+/**
+  * @brief  Returns the ETH MAC WakeUp event source
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval ETH MAC WakeUp event source
+  */
+uint32_t HAL_ETH_GetMACWakeUpSource(ETH_HandleTypeDef *heth)
+{
+  return heth->MACWakeUpEvent;
 }
 
 /**
   * @}
   */
-  
+
 /**
   * @}
   */
-  
-/** @addtogroup ETH_Private_Functions
+
+/** @addtogroup ETH_Private_Functions   ETH Private Functions
   * @{
   */
-
-/**
-  * @brief  Configures Ethernet MAC and DMA with default parameters.
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @param  err Ethernet Init error
-  * @retval HAL status
-  */
-static void ETH_MACDMAConfig(ETH_HandleTypeDef *heth, uint32_t err)
-{
-  ETH_MACInitTypeDef macinit;
-  ETH_DMAInitTypeDef dmainit;
-  uint32_t tmpreg = 0;
-  
-  if (err != ETH_SUCCESS) /* Auto-negotiation failed */
-  {
-    /* Set Ethernet duplex mode to Full-duplex */
-    (heth->Init).DuplexMode = ETH_MODE_FULLDUPLEX;
-    
-    /* Set Ethernet speed to 100M */
-    (heth->Init).Speed = ETH_SPEED_100M;
-  }
-  
-  /* Ethernet MAC default initialization **************************************/
-  macinit.Watchdog = ETH_WATCHDOG_ENABLE;
-  macinit.Jabber = ETH_JABBER_ENABLE;
-  macinit.InterFrameGap = ETH_INTERFRAMEGAP_96BIT;
-  macinit.CarrierSense = ETH_CARRIERSENCE_ENABLE;
-  macinit.ReceiveOwn = ETH_RECEIVEOWN_ENABLE;
-  macinit.LoopbackMode = ETH_LOOPBACKMODE_DISABLE;
-  if(heth->Init.ChecksumMode == ETH_CHECKSUM_BY_HARDWARE)
-  {
-    macinit.ChecksumOffload = ETH_CHECKSUMOFFLAOD_ENABLE;
-  }
-  else
-  {
-    macinit.ChecksumOffload = ETH_CHECKSUMOFFLAOD_DISABLE;
-  }
-  macinit.RetryTransmission = ETH_RETRYTRANSMISSION_DISABLE;
-  macinit.AutomaticPadCRCStrip = ETH_AUTOMATICPADCRCSTRIP_DISABLE;
-  macinit.BackOffLimit = ETH_BACKOFFLIMIT_10;
-  macinit.DeferralCheck = ETH_DEFFERRALCHECK_DISABLE;
-  macinit.ReceiveAll = ETH_RECEIVEAll_DISABLE;
-  macinit.SourceAddrFilter = ETH_SOURCEADDRFILTER_DISABLE;
-  macinit.PassControlFrames = ETH_PASSCONTROLFRAMES_BLOCKALL;
-  macinit.BroadcastFramesReception = ETH_BROADCASTFRAMESRECEPTION_ENABLE;
-  macinit.DestinationAddrFilter = ETH_DESTINATIONADDRFILTER_NORMAL;
-  macinit.PromiscuousMode = ETH_PROMISCUOUS_MODE_DISABLE;
-  macinit.MulticastFramesFilter = ETH_MULTICASTFRAMESFILTER_PERFECT;
-  macinit.UnicastFramesFilter = ETH_UNICASTFRAMESFILTER_PERFECT;
-  macinit.HashTableHigh = 0x0;
-  macinit.HashTableLow = 0x0;
-  macinit.PauseTime = 0x0;
-  macinit.ZeroQuantaPause = ETH_ZEROQUANTAPAUSE_DISABLE;
-  macinit.PauseLowThreshold = ETH_PAUSELOWTHRESHOLD_MINUS4;
-  macinit.UnicastPauseFrameDetect = ETH_UNICASTPAUSEFRAMEDETECT_DISABLE;
-  macinit.ReceiveFlowControl = ETH_RECEIVEFLOWCONTROL_DISABLE;
-  macinit.TransmitFlowControl = ETH_TRANSMITFLOWCONTROL_DISABLE;
-  macinit.VLANTagComparison = ETH_VLANTAGCOMPARISON_16BIT;
-  macinit.VLANTagIdentifier = 0x0;
-  
-  /*------------------------ ETHERNET MACCR Configuration --------------------*/
-  /* Get the ETHERNET MACCR value */
-  tmpreg = (heth->Instance)->MACCR;
-  /* Clear WD, PCE, PS, TE and RE bits */
-  tmpreg &= ETH_MACCR_CLEAR_MASK;
-  /* Set the WD bit according to ETH Watchdog value */
-  /* Set the JD: bit according to ETH Jabber value */
-  /* Set the IFG bit according to ETH InterFrameGap value */
-  /* Set the DCRS bit according to ETH CarrierSense value */
-  /* Set the FES bit according to ETH Speed value */ 
-  /* Set the DO bit according to ETH ReceiveOwn value */ 
-  /* Set the LM bit according to ETH LoopbackMode value */
-  /* Set the DM bit according to ETH Mode value */ 
-  /* Set the IPCO bit according to ETH ChecksumOffload value */
-  /* Set the DR bit according to ETH RetryTransmission value */
-  /* Set the ACS bit according to ETH AutomaticPadCRCStrip value */
-  /* Set the BL bit according to ETH BackOffLimit value */
-  /* Set the DC bit according to ETH DeferralCheck value */
-  tmpreg |= (uint32_t)(macinit.Watchdog | 
-                       macinit.Jabber | 
-                       macinit.InterFrameGap |
-                       macinit.CarrierSense |
-                       (heth->Init).Speed | 
-                       macinit.ReceiveOwn |
-                       macinit.LoopbackMode |
-                       (heth->Init).DuplexMode | 
-                       macinit.ChecksumOffload |    
-                       macinit.RetryTransmission | 
-                       macinit.AutomaticPadCRCStrip | 
-                       macinit.BackOffLimit | 
-                       macinit.DeferralCheck);
-  
-  /* Write to ETHERNET MACCR */
-  (heth->Instance)->MACCR = (uint32_t)tmpreg;
-  
-  /* Wait until the write operation will be taken into account:
-     at least four TX_CLK/RX_CLK clock cycles */
-  tmpreg = (heth->Instance)->MACCR;
-  HAL_Delay(ETH_REG_WRITE_DELAY);
-  (heth->Instance)->MACCR = tmpreg; 
-  
-  /*----------------------- ETHERNET MACFFR Configuration --------------------*/ 
-  /* Set the RA bit according to ETH ReceiveAll value */
-  /* Set the SAF and SAIF bits according to ETH SourceAddrFilter value */
-  /* Set the PCF bit according to ETH PassControlFrames value */
-  /* Set the DBF bit according to ETH BroadcastFramesReception value */
-  /* Set the DAIF bit according to ETH DestinationAddrFilter value */
-  /* Set the PR bit according to ETH PromiscuousMode value */
-  /* Set the PM, HMC and HPF bits according to ETH MulticastFramesFilter value */
-  /* Set the HUC and HPF bits according to ETH UnicastFramesFilter value */
-  /* Write to ETHERNET MACFFR */  
-  (heth->Instance)->MACFFR = (uint32_t)(macinit.ReceiveAll | 
-                                        macinit.SourceAddrFilter |
-                                        macinit.PassControlFrames |
-                                        macinit.BroadcastFramesReception | 
-                                        macinit.DestinationAddrFilter |
-                                        macinit.PromiscuousMode |
-                                        macinit.MulticastFramesFilter |
-                                        macinit.UnicastFramesFilter);
-   
-   /* Wait until the write operation will be taken into account:
-      at least four TX_CLK/RX_CLK clock cycles */
-   tmpreg = (heth->Instance)->MACFFR;
-   HAL_Delay(ETH_REG_WRITE_DELAY);
-   (heth->Instance)->MACFFR = tmpreg;
-   
-   /*--------------- ETHERNET MACHTHR and MACHTLR Configuration --------------*/
-   /* Write to ETHERNET MACHTHR */
-   (heth->Instance)->MACHTHR = (uint32_t)macinit.HashTableHigh;
-   
-   /* Write to ETHERNET MACHTLR */
-   (heth->Instance)->MACHTLR = (uint32_t)macinit.HashTableLow;
-   /*----------------------- ETHERNET MACFCR Configuration -------------------*/
-   
-   /* Get the ETHERNET MACFCR value */  
-   tmpreg = (heth->Instance)->MACFCR;
-   /* Clear xx bits */
-   tmpreg &= ETH_MACFCR_CLEAR_MASK;
-   
-   /* Set the PT bit according to ETH PauseTime value */
-   /* Set the DZPQ bit according to ETH ZeroQuantaPause value */
-   /* Set the PLT bit according to ETH PauseLowThreshold value */
-   /* Set the UP bit according to ETH UnicastPauseFrameDetect value */
-   /* Set the RFE bit according to ETH ReceiveFlowControl value */
-   /* Set the TFE bit according to ETH TransmitFlowControl value */ 
-   tmpreg |= (uint32_t)((macinit.PauseTime << 16) | 
-                        macinit.ZeroQuantaPause |
-                        macinit.PauseLowThreshold |
-                        macinit.UnicastPauseFrameDetect | 
-                        macinit.ReceiveFlowControl |
-                        macinit.TransmitFlowControl); 
-   
-   /* Write to ETHERNET MACFCR */
-   (heth->Instance)->MACFCR = (uint32_t)tmpreg;
-   
-   /* Wait until the write operation will be taken into account:
-   at least four TX_CLK/RX_CLK clock cycles */
-   tmpreg = (heth->Instance)->MACFCR;
-   HAL_Delay(ETH_REG_WRITE_DELAY);
-   (heth->Instance)->MACFCR = tmpreg;
-   
-   /*----------------------- ETHERNET MACVLANTR Configuration ----------------*/
-   /* Set the ETV bit according to ETH VLANTagComparison value */
-   /* Set the VL bit according to ETH VLANTagIdentifier value */  
-   (heth->Instance)->MACVLANTR = (uint32_t)(macinit.VLANTagComparison | 
-                                            macinit.VLANTagIdentifier);
-    
-    /* Wait until the write operation will be taken into account:
-       at least four TX_CLK/RX_CLK clock cycles */
-    tmpreg = (heth->Instance)->MACVLANTR;
-    HAL_Delay(ETH_REG_WRITE_DELAY);
-    (heth->Instance)->MACVLANTR = tmpreg;
-    
-    /* Ethernet DMA default initialization ************************************/
-    dmainit.DropTCPIPChecksumErrorFrame = ETH_DROPTCPIPCHECKSUMERRORFRAME_ENABLE;
-    dmainit.ReceiveStoreForward = ETH_RECEIVESTOREFORWARD_ENABLE;
-    dmainit.FlushReceivedFrame = ETH_FLUSHRECEIVEDFRAME_ENABLE;
-    dmainit.TransmitStoreForward = ETH_TRANSMITSTOREFORWARD_ENABLE;  
-    dmainit.TransmitThresholdControl = ETH_TRANSMITTHRESHOLDCONTROL_64BYTES;
-    dmainit.ForwardErrorFrames = ETH_FORWARDERRORFRAMES_DISABLE;
-    dmainit.ForwardUndersizedGoodFrames = ETH_FORWARDUNDERSIZEDGOODFRAMES_DISABLE;
-    dmainit.ReceiveThresholdControl = ETH_RECEIVEDTHRESHOLDCONTROL_64BYTES;
-    dmainit.SecondFrameOperate = ETH_SECONDFRAMEOPERARTE_ENABLE;
-    dmainit.AddressAlignedBeats = ETH_ADDRESSALIGNEDBEATS_ENABLE;
-    dmainit.FixedBurst = ETH_FIXEDBURST_ENABLE;
-    dmainit.RxDMABurstLength = ETH_RXDMABURSTLENGTH_32BEAT;
-    dmainit.TxDMABurstLength = ETH_TXDMABURSTLENGTH_32BEAT;
-    dmainit.EnhancedDescriptorFormat = ETH_DMAENHANCEDDESCRIPTOR_ENABLE;
-    dmainit.DescriptorSkipLength = 0x0;
-    dmainit.DMAArbitration = ETH_DMAARBITRATION_ROUNDROBIN_RXTX_1_1;
-    
-    /* Get the ETHERNET DMAOMR value */
-    tmpreg = (heth->Instance)->DMAOMR;
-    /* Clear xx bits */
-    tmpreg &= ETH_DMAOMR_CLEAR_MASK;
-    
-    /* Set the DT bit according to ETH DropTCPIPChecksumErrorFrame value */
-    /* Set the RSF bit according to ETH ReceiveStoreForward value */
-    /* Set the DFF bit according to ETH FlushReceivedFrame value */
-    /* Set the TSF bit according to ETH TransmitStoreForward value */
-    /* Set the TTC bit according to ETH TransmitThresholdControl value */
-    /* Set the FEF bit according to ETH ForwardErrorFrames value */
-    /* Set the FUF bit according to ETH ForwardUndersizedGoodFrames value */
-    /* Set the RTC bit according to ETH ReceiveThresholdControl value */
-    /* Set the OSF bit according to ETH SecondFrameOperate value */
-    tmpreg |= (uint32_t)(dmainit.DropTCPIPChecksumErrorFrame | 
-                         dmainit.ReceiveStoreForward |
-                         dmainit.FlushReceivedFrame |
-                         dmainit.TransmitStoreForward | 
-                         dmainit.TransmitThresholdControl |
-                         dmainit.ForwardErrorFrames |
-                         dmainit.ForwardUndersizedGoodFrames |
-                         dmainit.ReceiveThresholdControl |
-                         dmainit.SecondFrameOperate);
-    
-    /* Write to ETHERNET DMAOMR */
-    (heth->Instance)->DMAOMR = (uint32_t)tmpreg;
-    
-    /* Wait until the write operation will be taken into account:
-       at least four TX_CLK/RX_CLK clock cycles */
-    tmpreg = (heth->Instance)->DMAOMR;
-    HAL_Delay(ETH_REG_WRITE_DELAY);
-    (heth->Instance)->DMAOMR = tmpreg;
-    
-    /*----------------------- ETHERNET DMABMR Configuration ------------------*/
-    /* Set the AAL bit according to ETH AddressAlignedBeats value */
-    /* Set the FB bit according to ETH FixedBurst value */
-    /* Set the RPBL and 4*PBL bits according to ETH RxDMABurstLength value */
-    /* Set the PBL and 4*PBL bits according to ETH TxDMABurstLength value */
-    /* Set the Enhanced DMA descriptors bit according to ETH EnhancedDescriptorFormat value*/
-    /* Set the DSL bit according to ETH DesciptorSkipLength value */
-    /* Set the PR and DA bits according to ETH DMAArbitration value */
-    (heth->Instance)->DMABMR = (uint32_t)(dmainit.AddressAlignedBeats | 
-                                          dmainit.FixedBurst |
-                                          dmainit.RxDMABurstLength |    /* !! if 4xPBL is selected for Tx or Rx it is applied for the other */
-                                          dmainit.TxDMABurstLength |
-                                          dmainit.EnhancedDescriptorFormat |
-                                          (dmainit.DescriptorSkipLength << 2) |
-                                          dmainit.DMAArbitration |
-                                          ETH_DMABMR_USP); /* Enable use of separate PBL for Rx and Tx */
-     
-     /* Wait until the write operation will be taken into account:
-        at least four TX_CLK/RX_CLK clock cycles */
-     tmpreg = (heth->Instance)->DMABMR;
-     HAL_Delay(ETH_REG_WRITE_DELAY);
-     (heth->Instance)->DMABMR = tmpreg;
-
-     if((heth->Init).RxMode == ETH_RXINTERRUPT_MODE)
-     {
-       /* Enable the Ethernet Rx Interrupt */
-       __HAL_ETH_DMA_ENABLE_IT((heth), ETH_DMA_IT_NIS | ETH_DMA_IT_R);
-     }
-
-     /* Initialize MAC address in ethernet MAC */ 
-     ETH_MACAddressConfig(heth, ETH_MAC_ADDRESS0, heth->Init.MACAddr);
-}
-
-/**
-  * @brief  Configures the selected MAC address.
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @param  MacAddr The MAC address to configure
-  *          This parameter can be one of the following values:
-  *             @arg ETH_MAC_Address0: MAC Address0 
-  *             @arg ETH_MAC_Address1: MAC Address1 
-  *             @arg ETH_MAC_Address2: MAC Address2
-  *             @arg ETH_MAC_Address3: MAC Address3
-  * @param  Addr Pointer to MAC address buffer data (6 bytes)
-  * @retval HAL status
-  */
-static void ETH_MACAddressConfig(ETH_HandleTypeDef *heth, uint32_t MacAddr, uint8_t *Addr)
-{
-  uint32_t tmpreg;
-  
-  /* Check the parameters */
-  assert_param(IS_ETH_MAC_ADDRESS0123(MacAddr));
-  
-  /* Calculate the selected MAC address high register */
-  tmpreg = ((uint32_t)Addr[5] << 8) | (uint32_t)Addr[4];
-  /* Load the selected MAC address high register */
-  (*(__IO uint32_t *)((uint32_t)(ETH_MAC_ADDR_HBASE + MacAddr))) = tmpreg;
-  /* Calculate the selected MAC address low register */
-  tmpreg = ((uint32_t)Addr[3] << 24) | ((uint32_t)Addr[2] << 16) | ((uint32_t)Addr[1] << 8) | Addr[0];
-  
-  /* Load the selected MAC address low register */
-  (*(__IO uint32_t *)((uint32_t)(ETH_MAC_ADDR_LBASE + MacAddr))) = tmpreg;
-}
-
-/**
-  * @brief  Enables the MAC transmission.
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module  
-  * @retval None
-  */
-static void ETH_MACTransmissionEnable(ETH_HandleTypeDef *heth)
-{ 
-  __IO uint32_t tmpreg = 0;
-  
-  /* Enable the MAC transmission */
-  (heth->Instance)->MACCR |= ETH_MACCR_TE;
-  
-  /* Wait until the write operation will be taken into account:
-     at least four TX_CLK/RX_CLK clock cycles */
-  tmpreg = (heth->Instance)->MACCR;
-  HAL_Delay(ETH_REG_WRITE_DELAY);
-  (heth->Instance)->MACCR = tmpreg;
-}
-
-/**
-  * @brief  Disables the MAC transmission.
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module  
-  * @retval None
-  */
-static void ETH_MACTransmissionDisable(ETH_HandleTypeDef *heth)
-{ 
-  __IO uint32_t tmpreg = 0;
-  
-  /* Disable the MAC transmission */
-  (heth->Instance)->MACCR &= ~ETH_MACCR_TE;
-  
-  /* Wait until the write operation will be taken into account:
-     at least four TX_CLK/RX_CLK clock cycles */
-  tmpreg = (heth->Instance)->MACCR;
-  HAL_Delay(ETH_REG_WRITE_DELAY);
-  (heth->Instance)->MACCR = tmpreg;
-}
-
-/**
-  * @brief  Enables the MAC reception.
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module   
-  * @retval None
-  */
-static void ETH_MACReceptionEnable(ETH_HandleTypeDef *heth)
-{ 
-  __IO uint32_t tmpreg = 0;
-  
-  /* Enable the MAC reception */
-  (heth->Instance)->MACCR |= ETH_MACCR_RE;
-  
-  /* Wait until the write operation will be taken into account:
-     at least four TX_CLK/RX_CLK clock cycles */
-  tmpreg = (heth->Instance)->MACCR;
-  HAL_Delay(ETH_REG_WRITE_DELAY);
-  (heth->Instance)->MACCR = tmpreg;
-}
-
-/**
-  * @brief  Disables the MAC reception.
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module   
-  * @retval None
-  */
-static void ETH_MACReceptionDisable(ETH_HandleTypeDef *heth)
-{ 
-  __IO uint32_t tmpreg = 0;
-  
-  /* Disable the MAC reception */
-  (heth->Instance)->MACCR &= ~ETH_MACCR_RE; 
-  
-  /* Wait until the write operation will be taken into account:
-     at least four TX_CLK/RX_CLK clock cycles */
-  tmpreg = (heth->Instance)->MACCR;
-  HAL_Delay(ETH_REG_WRITE_DELAY);
-  (heth->Instance)->MACCR = tmpreg;
-}
-
-/**
-  * @brief  Enables the DMA transmission.
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module   
-  * @retval None
-  */
-static void ETH_DMATransmissionEnable(ETH_HandleTypeDef *heth)
-{
-  /* Enable the DMA transmission */
-  (heth->Instance)->DMAOMR |= ETH_DMAOMR_ST;  
-}
-
-/**
-  * @brief  Disables the DMA transmission.
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module   
-  * @retval None
-  */
-static void ETH_DMATransmissionDisable(ETH_HandleTypeDef *heth)
-{ 
-  /* Disable the DMA transmission */
-  (heth->Instance)->DMAOMR &= ~ETH_DMAOMR_ST;
-}
-
-/**
-  * @brief  Enables the DMA reception.
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module 
-  * @retval None
-  */
-static void ETH_DMAReceptionEnable(ETH_HandleTypeDef *heth)
-{  
-  /* Enable the DMA reception */
-  (heth->Instance)->DMAOMR |= ETH_DMAOMR_SR;  
-}
-
-/**
-  * @brief  Disables the DMA reception.
-  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module 
-  * @retval None
-  */
-static void ETH_DMAReceptionDisable(ETH_HandleTypeDef *heth)
-{ 
-  /* Disable the DMA reception */
-  (heth->Instance)->DMAOMR &= ~ETH_DMAOMR_SR;
-}
 
 /**
   * @brief  Clears the ETHERNET transmit FIFO.
@@ -2253,10 +2618,10 @@ static void ETH_DMAReceptionDisable(ETH_HandleTypeDef *heth)
 static void ETH_FlushTransmitFIFO(ETH_HandleTypeDef *heth)
 {
   __IO uint32_t tmpreg = 0;
-  
+
   /* Set the Flush Transmit FIFO bit */
   (heth->Instance)->DMAOMR |= ETH_DMAOMR_FTF;
-  
+
   /* Wait until the write operation will be taken into account:
      at least four TX_CLK/RX_CLK clock cycles */
   tmpreg = (heth->Instance)->DMAOMR;
@@ -2264,13 +2629,474 @@ static void ETH_FlushTransmitFIFO(ETH_HandleTypeDef *heth)
   (heth->Instance)->DMAOMR = tmpreg;
 }
 
+static void ETH_SetMACConfig(ETH_HandleTypeDef *heth,  ETH_MACConfigTypeDef *macconf)
+{
+  uint32_t tmpreg1;
+
+  /*------------------------ ETHERNET MACCR Configuration --------------------*/
+  /* Get the ETHERNET MACCR value */
+  tmpreg1 = (heth->Instance)->MACCR;
+  /* Clear WD, PCE, PS, TE and RE bits */
+  tmpreg1 &= ETH_MACCR_CLEAR_MASK;
+
+  tmpreg1 |= (uint32_t)(((uint32_t)((macconf->Watchdog == DISABLE) ? 1U : 0U) << 23U) |
+                        ((uint32_t)((macconf->Jabber == DISABLE) ? 1U : 0U) << 22U) |
+                        (uint32_t)macconf->InterPacketGapVal |
+                        ((uint32_t)macconf->CarrierSenseDuringTransmit << 16U) |
+                        macconf->Speed |
+                        ((uint32_t)((macconf->ReceiveOwn == DISABLE) ? 1U : 0U) << 13U) |
+                        ((uint32_t)macconf->LoopbackMode << 12U) |
+                        macconf->DuplexMode |
+                        ((uint32_t)macconf->ChecksumOffload << 10U) |
+                        ((uint32_t)((macconf->RetryTransmission == DISABLE) ? 1U : 0U) << 9U) |
+                        ((uint32_t)macconf->AutomaticPadCRCStrip << 7U) |
+                        macconf->BackOffLimit |
+                        ((uint32_t)macconf->DeferralCheck << 4U));
+
+  /* Write to ETHERNET MACCR */
+  (heth->Instance)->MACCR = (uint32_t)tmpreg1;
+
+  /* Wait until the write operation will be taken into account :
+  at least four TX_CLK/RX_CLK clock cycles */
+  tmpreg1 = (heth->Instance)->MACCR;
+  HAL_Delay(ETH_REG_WRITE_DELAY);
+  (heth->Instance)->MACCR = tmpreg1;
+
+  /*----------------------- ETHERNET MACFCR Configuration --------------------*/
+
+  /* Get the ETHERNET MACFCR value */
+  tmpreg1 = (heth->Instance)->MACFCR;
+  /* Clear xx bits */
+  tmpreg1 &= ETH_MACFCR_CLEAR_MASK;
+
+  tmpreg1 |= (uint32_t)((macconf->PauseTime << 16U) |
+                        (uint32_t)macconf->ZeroQuantaPause |
+                        macconf->PauseLowThreshold |
+                        (uint32_t)macconf->UnicastSlowProtocolPacketDetect |
+                        (uint32_t)macconf->ReceiveFlowControl |
+                        (uint32_t)macconf->TransmitFlowControl);
+
+  /* Write to ETHERNET MACFCR */
+  (heth->Instance)->MACFCR = (uint32_t)tmpreg1;
+
+  /* Wait until the write operation will be taken into account :
+  at least four TX_CLK/RX_CLK clock cycles */
+  tmpreg1 = (heth->Instance)->MACFCR;
+  HAL_Delay(ETH_REG_WRITE_DELAY);
+  (heth->Instance)->MACFCR = tmpreg1;
+}
+
+static void ETH_SetDMAConfig(ETH_HandleTypeDef *heth,  ETH_DMAConfigTypeDef *dmaconf)
+{
+  uint32_t tmpreg1;
+
+  /*----------------------- ETHERNET DMAOMR Configuration --------------------*/
+  /* Get the ETHERNET DMAOMR value */
+  tmpreg1 = (heth->Instance)->DMAOMR;
+  /* Clear xx bits */
+  tmpreg1 &= ETH_DMAOMR_CLEAR_MASK;
+
+  tmpreg1 |= (uint32_t)(((uint32_t)((dmaconf->DropTCPIPChecksumErrorFrame == DISABLE) ? 1U : 0U) << 26U) |
+                        ((uint32_t)dmaconf->ReceiveStoreForward << 25U) |
+                        ((uint32_t)((dmaconf->FlushRxPacket == DISABLE) ? 1U : 0U) << 20U) |
+                        ((uint32_t)dmaconf->TransmitStoreForward << 21U) |
+                        dmaconf->TransmitThresholdControl |
+                        ((uint32_t)dmaconf->ForwardErrorFrames << 7U) |
+                        ((uint32_t)dmaconf->ForwardUndersizedGoodFrames << 6U) |
+                        dmaconf->ReceiveThresholdControl |
+                        ((uint32_t)dmaconf->SecondFrameOperate << 2U));
+
+  /* Write to ETHERNET DMAOMR */
+  (heth->Instance)->DMAOMR = (uint32_t)tmpreg1;
+
+  /* Wait until the write operation will be taken into account:
+  at least four TX_CLK/RX_CLK clock cycles */
+  tmpreg1 = (heth->Instance)->DMAOMR;
+  HAL_Delay(ETH_REG_WRITE_DELAY);
+  (heth->Instance)->DMAOMR = tmpreg1;
+
+  /*----------------------- ETHERNET DMABMR Configuration --------------------*/
+  (heth->Instance)->DMABMR = (uint32_t)(((uint32_t)dmaconf->AddressAlignedBeats << 25U) |
+                                        dmaconf->BurstMode |
+                                        dmaconf->RxDMABurstLength | /* !! if 4xPBL is selected for Tx or
+                                                                       Rx it is applied for the other */
+                                        dmaconf->TxDMABurstLength |
+                                        ((uint32_t)dmaconf->EnhancedDescriptorFormat << 7U) |
+                                        (dmaconf->DescriptorSkipLength << 2U) |
+                                        dmaconf->DMAArbitration |
+                                        ETH_DMABMR_USP); /* Enable use of separate PBL for Rx and Tx */
+
+  /* Wait until the write operation will be taken into account:
+     at least four TX_CLK/RX_CLK clock cycles */
+  tmpreg1 = (heth->Instance)->DMABMR;
+  HAL_Delay(ETH_REG_WRITE_DELAY);
+  (heth->Instance)->DMABMR = tmpreg1;
+}
+
+/**
+  * @brief  Configures Ethernet MAC and DMA with default parameters.
+  *         called by HAL_ETH_Init() API.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval HAL status
+  */
+static void ETH_MACDMAConfig(ETH_HandleTypeDef *heth)
+{
+  ETH_MACConfigTypeDef macDefaultConf;
+  ETH_DMAConfigTypeDef dmaDefaultConf;
+
+  /*--------------- ETHERNET MAC registers default Configuration --------------*/
+  macDefaultConf.Watchdog = ENABLE;
+  macDefaultConf.Jabber = ENABLE;
+  macDefaultConf.InterPacketGapVal = ETH_INTERFRAMEGAP_96BIT;
+  macDefaultConf.CarrierSenseDuringTransmit = DISABLE;
+  macDefaultConf.ReceiveOwn = ENABLE;
+  macDefaultConf.LoopbackMode = DISABLE;
+  macDefaultConf.ChecksumOffload = ENABLE;
+  macDefaultConf.RetryTransmission = DISABLE;
+  macDefaultConf.AutomaticPadCRCStrip = DISABLE;
+  macDefaultConf.BackOffLimit = ETH_BACKOFFLIMIT_10;
+  macDefaultConf.DeferralCheck = DISABLE;
+  macDefaultConf.PauseTime = 0x0U;
+  macDefaultConf.ZeroQuantaPause = DISABLE;
+  macDefaultConf.PauseLowThreshold = ETH_PAUSELOWTHRESHOLD_MINUS4;
+  macDefaultConf.ReceiveFlowControl = DISABLE;
+  macDefaultConf.TransmitFlowControl = DISABLE;
+  macDefaultConf.Speed = ETH_SPEED_100M;
+  macDefaultConf.DuplexMode = ETH_FULLDUPLEX_MODE;
+  macDefaultConf.UnicastSlowProtocolPacketDetect = DISABLE;
+
+  /* MAC default configuration */
+  ETH_SetMACConfig(heth, &macDefaultConf);
+
+  /*--------------- ETHERNET DMA registers default Configuration --------------*/
+  dmaDefaultConf.DropTCPIPChecksumErrorFrame = ENABLE;
+  dmaDefaultConf.ReceiveStoreForward = ENABLE;
+  dmaDefaultConf.FlushRxPacket = ENABLE;
+  dmaDefaultConf.TransmitStoreForward = ENABLE;
+  dmaDefaultConf.TransmitThresholdControl = ETH_TRANSMITTHRESHOLDCONTROL_64BYTES;
+  dmaDefaultConf.ForwardErrorFrames = DISABLE;
+  dmaDefaultConf.ForwardUndersizedGoodFrames = DISABLE;
+  dmaDefaultConf.ReceiveThresholdControl = ETH_RECEIVEDTHRESHOLDCONTROL_64BYTES;
+  dmaDefaultConf.SecondFrameOperate = ENABLE;
+  dmaDefaultConf.AddressAlignedBeats = ENABLE;
+  dmaDefaultConf.BurstMode = ETH_BURSTLENGTH_FIXED;
+  dmaDefaultConf.RxDMABurstLength = ETH_RXDMABURSTLENGTH_32BEAT;
+  dmaDefaultConf.TxDMABurstLength = ETH_TXDMABURSTLENGTH_32BEAT;
+  dmaDefaultConf.EnhancedDescriptorFormat = ENABLE;
+  dmaDefaultConf.DescriptorSkipLength = 0x0U;
+  dmaDefaultConf.DMAArbitration = ETH_DMAARBITRATION_ROUNDROBIN_RXTX_1_1;
+
+  /* DMA default configuration */
+  ETH_SetDMAConfig(heth, &dmaDefaultConf);
+}
+
+/**
+  * @brief  Configures the selected MAC address.
+  * @param  heth pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  MacAddr The MAC address to configure
+  *          This parameter can be one of the following values:
+  *             @arg ETH_MAC_Address0: MAC Address0
+  *             @arg ETH_MAC_Address1: MAC Address1
+  *             @arg ETH_MAC_Address2: MAC Address2
+  *             @arg ETH_MAC_Address3: MAC Address3
+  * @param  Addr Pointer to MAC address buffer data (6 bytes)
+  * @retval HAL status
+  */
+static void ETH_MACAddressConfig(ETH_HandleTypeDef *heth, uint32_t MacAddr, uint8_t *Addr)
+{
+  uint32_t tmpreg1;
+
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(heth);
+
+  /* Calculate the selected MAC address high register */
+  tmpreg1 = ((uint32_t)Addr[5U] << 8U) | (uint32_t)Addr[4U];
+  /* Load the selected MAC address high register */
+  (*(__IO uint32_t *)((uint32_t)(ETH_MAC_ADDR_HBASE + MacAddr))) = tmpreg1;
+  /* Calculate the selected MAC address low register */
+  tmpreg1 = ((uint32_t)Addr[3U] << 24U) | ((uint32_t)Addr[2U] << 16U) | ((uint32_t)Addr[1U] << 8U) | Addr[0U];
+
+  /* Load the selected MAC address low register */
+  (*(__IO uint32_t *)((uint32_t)(ETH_MAC_ADDR_LBASE + MacAddr))) = tmpreg1;
+}
+
+/**
+  * @brief  Initializes the DMA Tx descriptors.
+  *         called by HAL_ETH_Init() API.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval None
+  */
+static void ETH_DMATxDescListInit(ETH_HandleTypeDef *heth)
+{
+  ETH_DMADescTypeDef *dmatxdesc;
+  uint32_t i;
+
+  /* Fill each DMATxDesc descriptor with the right values */
+  for (i = 0; i < (uint32_t)ETH_TX_DESC_CNT; i++)
+  {
+    dmatxdesc = heth->Init.TxDesc + i;
+
+    WRITE_REG(dmatxdesc->DESC0, 0x0);
+    WRITE_REG(dmatxdesc->DESC1, 0x0);
+    WRITE_REG(dmatxdesc->DESC2, 0x0);
+    WRITE_REG(dmatxdesc->DESC3, 0x0);
+
+    WRITE_REG(heth->TxDescList.TxDesc[i], (uint32_t)dmatxdesc);
+
+    /* Set Second Address Chained bit */
+    SET_BIT(dmatxdesc->DESC0, ETH_DMATXDESC_TCH);
+
+    if (i < ((uint32_t)ETH_TX_DESC_CNT - 1U))
+    {
+      WRITE_REG(dmatxdesc->DESC3, (uint32_t)(heth->Init.TxDesc + i + 1U));
+    }
+    else
+    {
+      WRITE_REG(dmatxdesc->DESC3, (uint32_t)(heth->Init.TxDesc));
+    }
+
+    /* Set the DMA Tx descriptors checksum insertion */
+    SET_BIT(dmatxdesc->DESC0, ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL);
+  }
+
+  heth->TxDescList.CurTxDesc = 0;
+
+  /* Set Transmit Descriptor List Address */
+  WRITE_REG(heth->Instance->DMATDLAR, (uint32_t) heth->Init.TxDesc);
+}
+
+/**
+  * @brief  Initializes the DMA Rx descriptors in chain mode.
+  *         called by HAL_ETH_Init() API.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval None
+  */
+static void ETH_DMARxDescListInit(ETH_HandleTypeDef *heth)
+{
+  ETH_DMADescTypeDef *dmarxdesc;
+  uint32_t i;
+
+  for (i = 0; i < (uint32_t)ETH_RX_DESC_CNT; i++)
+  {
+    dmarxdesc =  heth->Init.RxDesc + i;
+
+    WRITE_REG(dmarxdesc->DESC0, 0x0);
+    WRITE_REG(dmarxdesc->DESC1, 0x0);
+    WRITE_REG(dmarxdesc->DESC2, 0x0);
+    WRITE_REG(dmarxdesc->DESC3, 0x0);
+    WRITE_REG(dmarxdesc->BackupAddr0, 0x0);
+    WRITE_REG(dmarxdesc->BackupAddr1, 0x0);
+
+    /* Set Own bit of the Rx descriptor Status */
+    dmarxdesc->DESC0 = ETH_DMARXDESC_OWN;
+
+    /* Set Buffer1 size and Second Address Chained bit */
+    dmarxdesc->DESC1 = ETH_DMARXDESC_RCH | ETH_RX_BUF_SIZE;
+
+    /* Enable Ethernet DMA Rx Descriptor interrupt */
+    dmarxdesc->DESC1 &= ~ETH_DMARXDESC_DIC;
+
+    /* Set Rx descritors addresses */
+    WRITE_REG(heth->RxDescList.RxDesc[i], (uint32_t)dmarxdesc);
+
+    if (i < ((uint32_t)ETH_RX_DESC_CNT - 1U))
+    {
+      WRITE_REG(dmarxdesc->DESC3, (uint32_t)(heth->Init.RxDesc + i + 1U));
+    }
+    else
+    {
+      WRITE_REG(dmarxdesc->DESC3, (uint32_t)(heth->Init.RxDesc));
+    }
+  }
+
+  WRITE_REG(heth->RxDescList.RxDescIdx, 0);
+  WRITE_REG(heth->RxDescList.RxDescCnt, 0);
+  WRITE_REG(heth->RxDescList.RxBuildDescIdx, 0);
+  WRITE_REG(heth->RxDescList.RxBuildDescCnt, 0);
+  WRITE_REG(heth->RxDescList.ItMode, 0);
+
+  /* Set Receive Descriptor List Address */
+  WRITE_REG(heth->Instance->DMARDLAR, (uint32_t) heth->Init.RxDesc);
+}
+
+/**
+  * @brief  Prepare Tx DMA descriptor before transmission.
+  *         called by HAL_ETH_Transmit_IT and HAL_ETH_Transmit_IT() API.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  pTxConfig: Tx packet configuration
+  * @param  ItMode: Enable or disable Tx EOT interrept
+  * @retval Status
+  */
+static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, ETH_TxPacketConfig *pTxConfig, uint32_t ItMode)
+{
+  ETH_TxDescListTypeDef *dmatxdesclist = &heth->TxDescList;
+  uint32_t descidx = dmatxdesclist->CurTxDesc;
+  uint32_t firstdescidx = dmatxdesclist->CurTxDesc;
+  uint32_t idx;
+  uint32_t descnbr = 0;
+  ETH_DMADescTypeDef *dmatxdesc = (ETH_DMADescTypeDef *)dmatxdesclist->TxDesc[descidx];
+
+  ETH_BufferTypeDef  *txbuffer = pTxConfig->TxBuffer;
+  uint32_t           bd_count = 0;
+
+  /* Current Tx Descriptor Owned by DMA: cannot be used by the application  */
+  if ((READ_BIT(dmatxdesc->DESC0, ETH_DMATXDESC_OWN) == ETH_DMATXDESC_OWN)
+      || (dmatxdesclist->PacketAddress[descidx] != NULL))
+  {
+    return HAL_ETH_ERROR_BUSY;
+  }
+
+
+  descnbr += 1U;
+
+  /* Set header or buffer 1 address */
+  WRITE_REG(dmatxdesc->DESC2, (uint32_t)txbuffer->buffer);
+
+  /* Set header or buffer 1 Length */
+  MODIFY_REG(dmatxdesc->DESC1, ETH_DMATXDESC_TBS1, txbuffer->len);
+
+  if (READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_CSUM) != 0U)
+  {
+    MODIFY_REG(dmatxdesc->DESC0, ETH_DMATXDESC_CIC, pTxConfig->ChecksumCtrl);
+  }
+
+  if (READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_CRCPAD) != 0U)
+  {
+    MODIFY_REG(dmatxdesc->DESC0, ETH_CRC_PAD_DISABLE, pTxConfig->CRCPadCtrl);
+  }
+
+
+  if (READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_VLANTAG) != 0U)
+  {
+    /* Set Vlan Type */
+    SET_BIT(dmatxdesc->DESC0, ETH_DMATXDESC_VF);
+  }
+
+  /* Mark it as First Descriptor */
+  SET_BIT(dmatxdesc->DESC0, ETH_DMATXDESC_FS);
+
+  /* Ensure rest of descriptor is written to RAM before the OWN bit */
+  __DMB();
+  /* set OWN bit of FIRST descriptor */
+  SET_BIT(dmatxdesc->DESC0, ETH_DMATXDESC_OWN);
+
+  /* only if the packet is split into more than one descriptors > 1 */
+  while (txbuffer->next != NULL)
+  {
+    /* Clear the LD bit of previous descriptor */
+    CLEAR_BIT(dmatxdesc->DESC0, ETH_DMATXDESC_LS);
+    if (ItMode != ((uint32_t)RESET))
+    {
+      /* Set Interrupt on completion bit */
+      SET_BIT(dmatxdesc->DESC0, ETH_DMATXDESC_IC);
+    }
+    else
+    {
+      /* Clear Interrupt on completion bit */
+      CLEAR_BIT(dmatxdesc->DESC0, ETH_DMATXDESC_IC);
+    }
+    /* Increment current tx descriptor index */
+    INCR_TX_DESC_INDEX(descidx, 1U);
+    /* Get current descriptor address */
+    dmatxdesc = (ETH_DMADescTypeDef *)dmatxdesclist->TxDesc[descidx];
+
+    /* Clear the FD bit of new Descriptor */
+    CLEAR_BIT(dmatxdesc->DESC0, ETH_DMATXDESC_FS);
+
+    /* Current Tx Descriptor Owned by DMA: cannot be used by the application  */
+    if ((READ_BIT(dmatxdesc->DESC0, ETH_DMATXDESC_OWN) == ETH_DMATXDESC_OWN)
+        || (dmatxdesclist->PacketAddress[descidx] != NULL))
+    {
+      descidx = firstdescidx;
+      dmatxdesc = (ETH_DMADescTypeDef *)dmatxdesclist->TxDesc[descidx];
+
+      /* clear previous desc own bit */
+      for (idx = 0; idx < descnbr; idx ++)
+      {
+        /* Ensure rest of descriptor is written to RAM before the OWN bit */
+        __DMB();
+
+        CLEAR_BIT(dmatxdesc->DESC0, ETH_DMATXDESC_OWN);
+
+        /* Increment current tx descriptor index */
+        INCR_TX_DESC_INDEX(descidx, 1U);
+        /* Get current descriptor address */
+        dmatxdesc = (ETH_DMADescTypeDef *)dmatxdesclist->TxDesc[descidx];
+      }
+
+      return HAL_ETH_ERROR_BUSY;
+    }
+
+    descnbr += 1U;
+
+    /* Get the next Tx buffer in the list */
+    txbuffer = txbuffer->next;
+
+    /* Set header or buffer 1 address */
+    WRITE_REG(dmatxdesc->DESC2, (uint32_t)txbuffer->buffer);
+
+    /* Set header or buffer 1 Length */
+    MODIFY_REG(dmatxdesc->DESC1, ETH_DMATXDESC_TBS1, txbuffer->len);
+
+    bd_count += 1U;
+
+    /* Ensure rest of descriptor is written to RAM before the OWN bit */
+    __DMB();
+    /* Set Own bit */
+    SET_BIT(dmatxdesc->DESC0, ETH_DMATXDESC_OWN);
+  }
+
+  if (ItMode != ((uint32_t)RESET))
+  {
+    /* Set Interrupt on completion bit */
+    SET_BIT(dmatxdesc->DESC0, ETH_DMATXDESC_IC);
+  }
+  else
+  {
+    /* Clear Interrupt on completion bit */
+    CLEAR_BIT(dmatxdesc->DESC0, ETH_DMATXDESC_IC);
+  }
+
+  /* Mark it as LAST descriptor */
+  SET_BIT(dmatxdesc->DESC0, ETH_DMATXDESC_LS);
+  /* Save the current packet address to expose it to the application */
+  dmatxdesclist->PacketAddress[descidx] = dmatxdesclist->CurrentPacketAddress;
+
+  dmatxdesclist->CurTxDesc = descidx;
+
+  /* disable the interrupt */
+  __disable_irq();
+
+  dmatxdesclist->BuffersInUse += bd_count + 1U;
+
+  /* Enable interrupts back */
+  __enable_irq();
+
+
+  /* Return function status */
+  return HAL_ETH_ERROR_NONE;
+}
+
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
 static void ETH_InitCallbacksToDefault(ETH_HandleTypeDef *heth)
 {
   /* Init the ETH Callback settings */
-  heth->TxCpltCallback       = HAL_ETH_TxCpltCallback; /* Legacy weak TxCpltCallback   */
-  heth->RxCpltCallback       = HAL_ETH_RxCpltCallback; /* Legacy weak RxCpltCallback   */
-  heth->DMAErrorCallback     = HAL_ETH_ErrorCallback;  /* Legacy weak DMAErrorCallback */
+  heth->TxCpltCallback   = HAL_ETH_TxCpltCallback;    /* Legacy weak TxCpltCallback   */
+  heth->RxCpltCallback   = HAL_ETH_RxCpltCallback;    /* Legacy weak RxCpltCallback   */
+  heth->ErrorCallback    = HAL_ETH_ErrorCallback;     /* Legacy weak ErrorCallback */
+  heth->PMTCallback      = HAL_ETH_PMTCallback;       /* Legacy weak PMTCallback      */
+  heth->WakeUpCallback   = HAL_ETH_WakeUpCallback;    /* Legacy weak WakeUpCallback   */
+  heth->rxLinkCallback   = HAL_ETH_RxLinkCallback;    /* Legacy weak RxLinkCallback   */
+  heth->txFreeCallback   = HAL_ETH_TxFreeCallback;    /* Legacy weak TxFreeCallback   */
+#ifdef HAL_ETH_USE_PTP
+  heth->txPtpCallback    = HAL_ETH_TxPtpCallback;     /* Legacy weak TxPtpCallback   */
+#endif /* HAL_ETH_USE_PTP */
+  heth->rxAllocateCallback = HAL_ETH_RxAllocateCallback; /* Legacy weak RxAllocateCallback */
 }
 #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
 
@@ -2278,11 +3104,13 @@ static void ETH_InitCallbacksToDefault(ETH_HandleTypeDef *heth)
   * @}
   */
 
-#endif /* ETH */
-#endif /* HAL_ETH_MODULE_ENABLED */
 /**
   * @}
   */
+
+#endif /* ETH */
+
+#endif /* HAL_ETH_MODULE_ENABLED */
 
 /**
   * @}


### PR DESCRIPTION
The reworked Ethernet HAL driver brings multiple changes and a compatibility break vs. previous Ethernet HAL driver.
Main changes are listed here:
- Add support of PTP with timestamp and ARP
- Rework packets reception and buffers allocation for better integration and performance, solve received data corruption issue, and handle "receive buffer unavailable" condition
- Rework packets transmission and buffers allocation (using interrupts instead of polling) and prevent packets lock during transmission
- Enhance DMA management
- Decouple Ethernet HAL driver from PHY driver
- Enhance maximum throughput in Rx (91Mbs) and Tx (93Mbs)
- Increase footprint (new driver size is 15% more than previous driver) due to several register accesses moved from application's side to driver's
- Full integration with LwIP (with and without FreeRTOS) and NetXDuo with ThreadX
- MISRA-C 2012, code coverage analysis, static code analysis and robustness validation added
- Add the 'const' qualifier to comply to MISRA-C rule 8.13
